### PR TITLE
List all the devices we know of by default

### DIFF
--- a/internal/controller/spectrumcluster.go
+++ b/internal/controller/spectrumcluster.go
@@ -22,6 +22,42 @@ func NewSpectrumCluster(daemon_nodeSelector map[string]string) *unstructured.Uns
 								"devicePath": "/dev/disk/by-id/*",
 								"deviceType": "generic",
 							},
+							map[string]any{
+								"devicePath": "/dev/sd*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/hd*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/scini*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/pmem*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/nvm*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/dm-*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/vpath*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/dasd*",
+								"deviceType": "generic",
+							},
+							map[string]any{
+								"devicePath": "/dev/emcpower*",
+								"deviceType": "generic",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Starting with v5.2.3.x symlinks are finally supported this made us add
/dev/disk/by-id/* in our default cluster config [1]

The problem with this is that once you specify an entry in `localDevicePaths`
no other device will be accepted. So by default let's list all the
currently documented accepted devices in addition to /dev/disk/by-id/*.

Tested and this fixed the partially-shared issues we were observing.

[1] https://www.ibm.com/docs/en/scalecontainernative/5.2.2?topic=systems-local-file-system#specify-device-names
