### PR TITLE
Also build and push must-gather when releasing

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,7 +5,8 @@ VERSION=$(cat VERSION.txt)
 
 make USE_IMAGE_DIGESTS="" bundle generate manifests docker-build docker-push \
     bundle-build bundle-push catalog-build catalog-push \
-    console-build console-push devicefinder-docker-build devicefinder-docker-push
+    console-build console-push devicefinder-docker-build devicefinder-docker-push \
+    must-gather-docker-build must-gather-docker-push
 
 podman tag quay.io/openshift-storage-scale/openshift-fusion-access-catalog:${VERSION} quay.io/openshift-storage-scale/openshift-fusion-access-catalog:stable
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Added must-gather-docker-build and must-gather-docker-push targets to the release script to include must-gather image in the release workflow