### PR TITLE
[draft] add pull secret mount in operator's pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ bundle_tmp*/
 must-gather.local.*/
 
 build/*
-
-bundle.konflux.Dockerfile
 bundle/*
 
-bundle.Dockerfile
+*Dockerfile

--- a/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Dockerfile
+    value: operator.Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -171,18 +171,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: export SECRET_NAME=external-registry-pull-secret && scripts/generate-konflux-dockerfile.sh operator
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name
@@ -441,7 +466,7 @@ spec:
         - name: name
           value: sast-coverity-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:07cb09253da53235f83d1a2327faebb8505091c509fc1e3af12a43cfe34f63a6
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:8eb97a206debc398e4ffc58a112b04be32cfa59447e6ea9d650b29de858f96a2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
@@ -247,6 +247,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_SECRET
+        value: external-registry-pull-secret
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/controller-rhel9-operator-1-0-push.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-push.yaml
@@ -244,6 +244,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_SECRET
+        value: external-registry-pull-secret
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/controller-rhel9-operator-1-0-push.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-push.yaml
@@ -168,18 +168,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: export SECRET_NAME=external-registry-pull-secret && scripts/generate-konflux-dockerfile.sh operator
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/devicefinder-1-0-pull-request.yaml
+++ b/.tekton/devicefinder-1-0-pull-request.yaml
@@ -170,18 +170,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh devicefinder
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/devicefinder-1-0-push.yaml
+++ b/.tekton/devicefinder-1-0-push.yaml
@@ -167,18 +167,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh devicefinder
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/must-gather-1-0-pull-request.yaml
+++ b/.tekton/must-gather-1-0-pull-request.yaml
@@ -166,18 +166,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh must-gather
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/must-gather-1-0-push.yaml
+++ b/.tekton/must-gather-1-0-push.yaml
@@ -163,18 +163,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh must-gather
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
-github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -ex
 
+# Placeholder env variable for the name of the secret defined in the build-container task in Konflux.
+# Konflux will mount the secret in /run/secrets/{secret_name}/{contents_of_the_secret}, but
+# our dev environment doesn't have that {secret_name} and it should be agnostic to it.
+# Hence empty by default
+SECRET_NAME=
 # GOOS and GOARCH will be set if calling from make. Dockerfile calls this script
 # directly without calling make so the default values need to be set here also.
 [[ -z "$GOOS" ]] && GOOS=linux

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -ex
 
-# Placeholder env variable for the name of the secret defined in the build-container task in Konflux.
-# Konflux will mount the secret in /run/secrets/{secret_name}/{contents_of_the_secret}, but
-# our dev environment doesn't have that {secret_name} and it should be agnostic to it.
-# Hence empty by default
-SECRET_NAME=
 # GOOS and GOARCH will be set if calling from make. Dockerfile calls this script
 # directly without calling make so the default values need to be set here also.
 [[ -z "$GOOS" ]] && GOOS=linux
@@ -32,8 +27,9 @@ esac
 go version
 
 touch internal/controller/pull.txt
-if [ -f "/run/secrets/pull" ]; then
-    cp -f /run/secrets/pull internal/controller/pull.txt
+if [ -f "/run/secrets/{SECRET_NAME}/pull" ]; then
+    echo "Secret found in /run/secrets/{SECRET_NAME}/pull"
+    cp -f /run/secrets/{SECRET_NAME}/pull internal/controller/pull.txt
 fi
 
 GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go $EXTRA -ldflags="${LDFLAGS}" cmd/main.go

--- a/scripts/generate-konflux-dockerfile.sh
+++ b/scripts/generate-konflux-dockerfile.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Expose the operator's version as an env variable
+export VERSION=$(cat VERSION.txt)
+# Generate the Dockefile replacing the VERSION value in the label to match the current version
+envsubst < templates/$1.Dockerfile.template >$1.Dockerfile

--- a/templates/bundle.Dockerfile.template
+++ b/templates/bundle.Dockerfile.template
@@ -2,6 +2,8 @@
 
 FROM scratch
 
+ARG VERSION=1.0
+
 LABEL controller-rhel9-operator=${OPERATOR_IMG}
 LABEL devicefinder=${DEVICEFINDER_IMAGE}
 LABEL console-plugin=${CONSOLE_PLUGIN_IMAGE}

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -10,6 +10,8 @@ RUN make build-devicefinder
 # Change this once ubi10 moves out of beta
 FROM registry.redhat.io/ubi10-beta/ubi:latest
 
+ARG VERSION=1.0
+
 COPY --from=builder /workspace/_output/bin/devicefinder /usr/bin/
 
 ENTRYPOINT ["/usr/bin/devicefinder"]
@@ -23,8 +25,8 @@ LABEL \
     distribution-scope="public" \
     name="openshift-fusion-access-devicefinder" \
     summary="Device Finder" \
-    release="v1.0" \
-    version="v1.0" \
+    release="v${VERSION}" \
+    version="v${VERSION}" \
     maintainer="Red Hat jgil@redhat.com" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
     vendor="Red Hat, Inc." \

--- a/templates/must-gather.Dockerfile.template
+++ b/templates/must-gather.Dockerfile.template
@@ -1,5 +1,7 @@
 FROM registry.redhat.io/multicluster-engine/must-gather-rhel9:v2.8 AS builder
 
+ARG VERSION=1.0
+
 # Copy our scripts
 COPY collection-scripts/* /usr/bin/
 
@@ -13,8 +15,8 @@ LABEL \
     distribution-scope="public" \
     name="openshift-fusion-access-must-gather-rhel9" \
     vendor="Red Hat, Inc." \
-    version="v1.0" \
-    release="v1.0" \
+    release="v${VERSION}" \
+    version="v${VERSION}" \
     summary="Must gather image" \
     description="" \
     maintainer="Red Hat jgil@redhat.com" \

--- a/templates/operator.Dockerfile.template
+++ b/templates/operator.Dockerfile.template
@@ -27,7 +27,7 @@ RUN mkdir licenses
 COPY LICENSE licenses/
 
 # Build
-RUN --mount=type=secret,id=pull export SECRET_NAME=${SECRET_NAME}; hack/build.sh
+RUN --mount=type=secret,id=${SECRET_NAME}/pull export SECRET_NAME=${SECRET_NAME}; hack/build.sh
 
 # UBI is larger (158Mb vs. 56Mb) but approved by RH
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/templates/operator.Dockerfile.template
+++ b/templates/operator.Dockerfile.template
@@ -1,3 +1,4 @@
+
 ARG TARGETARCH=amd64
 
 FROM --platform=linux/$TARGETARCH brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 AS builder
@@ -26,7 +27,7 @@ RUN mkdir licenses
 COPY LICENSE licenses/
 
 # Build
-RUN --mount=type=secret,id=pull hack/build.sh
+RUN --mount=type=secret,id=pull export SECRET_NAME=${SECRET_NAME}; hack/build.sh
 
 # UBI is larger (158Mb vs. 56Mb) but approved by RH
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
@@ -35,6 +36,10 @@ COPY --from=builder /workspace/files/ /files/
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/licenses/ /licenses/
 USER 65532:65532
+
+ARG VERSION=1.0
+
+
 
 ENTRYPOINT ["/manager"]
 
@@ -47,8 +52,8 @@ LABEL \
     distribution-scope="public" \
     name="openshift-fusion-access-controller" \
     summary="Controller" \
-    release="v1.0" \
-    version="v1.0" \
+    release="v${VERSION}" \
+    version="v${VERSION}" \
     maintainer="Red Hat jgil@redhat.com" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
     vendor="Red Hat, Inc." \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -272,6 +272,8 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rogpeppe/go-internal v1.13.1
+## explicit; go 1.22
 # github.com/spf13/cobra v1.9.1
 ## explicit; go 1.15
 github.com/spf13/cobra


### PR DESCRIPTION
## Summary by Sourcery

Modify the Tekton pipeline configuration to add a pull secret mount for external registry access during the container build task

New Features:
- Add a new task for generating Dockerfile with script execution and OCI artifact handling

Enhancements:
- Introduce a workspace for mounting external registry pull secret in the build-container task