### PR TITLE
Use templates to generate dockefiles on the fly and add task in konflux pipelines for that purpose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ bundle_tmp*/
 must-gather.local.*/
 
 build/*
-
-bundle.konflux.Dockerfile
 bundle/*
 
-bundle.Dockerfile
+*Dockerfile

--- a/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Dockerfile
+    value: operator.Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -171,18 +171,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: export SECRET_NAME=external-registry-pull-secret && scripts/generate-konflux-dockerfile.sh operator
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name
@@ -441,7 +466,7 @@ spec:
         - name: name
           value: sast-coverity-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:07cb09253da53235f83d1a2327faebb8505091c509fc1e3af12a43cfe34f63a6
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:8eb97a206debc398e4ffc58a112b04be32cfa59447e6ea9d650b29de858f96a2
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/controller-rhel9-operator-1-0-push.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-push.yaml
@@ -168,18 +168,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: export SECRET_NAME=external-registry-pull-secret && scripts/generate-konflux-dockerfile.sh operator
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/devicefinder-1-0-pull-request.yaml
+++ b/.tekton/devicefinder-1-0-pull-request.yaml
@@ -170,18 +170,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh devicefinder
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/devicefinder-1-0-push.yaml
+++ b/.tekton/devicefinder-1-0-push.yaml
@@ -167,18 +167,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh devicefinder
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/must-gather-1-0-pull-request.yaml
+++ b/.tekton/must-gather-1-0-pull-request.yaml
@@ -166,18 +166,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh must-gather
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/must-gather-1-0-push.yaml
+++ b/.tekton/must-gather-1-0-push.yaml
@@ -163,18 +163,43 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+    - name: generate-dockerfile
+      params:
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: SCRIPT
+        value: scripts/generate-konflux-dockerfile.sh must-gather
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/konflux-ci/operator-sdk-builder:latest
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: run-script-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+        - name: kind
+          value: task
+        resolver: bundles
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       runAfter:
-      - clone-repository
+      - generate-dockerfile
       taskRef:
         params:
         - name: name

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= $(shell cat VERSION.txt)
+export VERSION ?= $(shell cat VERSION.txt)
+
+
+OPERATOR_DOCKERFILE ?= Dockerfile
+DEVICEFINDER_DOCKERFILE ?= devicefinder.Dockerfile
+MUST_GATHER_DOCKERFILE ?= must-gather.Dockerfile
 
 # Version of yaml file to generate rbacs from
 RBAC_VERSION ?= v5.2.2.0
@@ -192,13 +197,30 @@ clean: ## Remove build artifacts and downloaded tools
 	find bin/ -exec chmod +w "{}" \;
 	rm -rf ./manager ./bin/* ./cover.out ./coverage.html
 
+# Generate Dockerfile using the template. It uses envsubst to replace the value of the version label in the container
+.PHONY: generate-dockerfile-operator
+generate-dockerfile-operator:
+	envsubst < templates/operator.Dockerfile.template > $(OPERATOR_DOCKERFILE)
+
+# Generate Dockerfile using the template. It uses envsubst to replace the value of the version label in the container
+.PHONY: generate-dockefile-devicefinder
+generate-dockefile-devicefinder:
+	envsubst < templates/devicefinder.Dockerfile.template > $(DEVICEFINDER_DOCKERFILE)
+
+# Generate Dockerfile using the template. It uses envsubst to replace the value of the version label in the container
+.PHONY: generate-dockefile-must-gather
+generate-dockefile-must-gather:
+	envsubst < templates/must-gather.Dockerfile.template > $(MUST_GATHER_DOCKERFILE)
+
+
+
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 TARGETARCH ?= amd64
 .PHONY: docker-build
-docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build --secret id=pull,src=$(PULLFILE) --build-arg TARGETARCH=$(TARGETARCH) -t $(OPERATOR_IMG) .
+docker-build: generate-dockerfile-operator ## Build docker image with the manager.
+	$(CONTAINER_TOOL) build --secret id=pull,src=$(PULLFILE) --build-arg TARGETARCH=$(TARGETARCH) -t $(OPERATOR_IMG) -f $(CURPATH)/$(OPERATOR_DOCKERFILE) .
 	$(CONTAINER_TOOL) tag $(OPERATOR_IMG) $(IMAGE_TAG_BASE)-operator:latest
 
 .PHONY: docker-push
@@ -214,16 +236,16 @@ console-push: ## Push the console image
 	$(CONTAINER_TOOL) push $(CONSOLE_PLUGIN_IMAGE)
 
 .PHONY: devicefinder-docker-build
-devicefinder-docker-build: ## Build docker image of the devicefinder
-	$(CONTAINER_TOOL) build -t $(DEVICEFINDER_IMAGE) -f $(CURPATH)/devicefinder.Dockerfile .
+devicefinder-docker-build: generate-dockefile-devicefinder ## Build docker image of the devicefinder
+	$(CONTAINER_TOOL) build -t $(DEVICEFINDER_IMAGE) -f $(CURPATH)/${DEVICEFINDER_DOCKERFILE} .
 
 .PHONY: devicefinder-docker-push
 devicefinder-docker-push: ## Push docker image of the devicefinder
 	$(CONTAINER_TOOL) push $(DEVICEFINDER_IMAGE)
 
 .PHONY: must-gather-docker-build
-must-gather-docker-build: ## Build docker image of the must gather container
-	$(CONTAINER_TOOL) build --platform=linux/$(TARGETARCH) -t $(MUST_GATHER_IMAGE) -f $(CURPATH)/must-gather.Dockerfile .
+must-gather-docker-build: generate-dockefile-must-gather ## Build docker image of the must gather container
+	$(CONTAINER_TOOL) build --platform=linux/$(TARGETARCH) -t $(MUST_GATHER_IMAGE) -f $(CURPATH)/${MUST_GATHER_DOCKERFILE} .
 
 .PHONY: must-gather-docker-push
 must-gather-docker-push: ## Push docker image of the must gather container

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
-github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/scripts/generate-konflux-dockerfile.sh
+++ b/scripts/generate-konflux-dockerfile.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Expose the operator's version as an env variable
+export VERSION=$(cat VERSION.txt)
+# Generate the Dockefile replacing the VERSION value in the label to match the current version
+envsubst < templates/$1.Dockerfile.template >$1.Dockerfile

--- a/templates/bundle.Dockerfile.template
+++ b/templates/bundle.Dockerfile.template
@@ -2,6 +2,8 @@
 
 FROM scratch
 
+ARG VERSION=1.0
+
 LABEL controller-rhel9-operator=${OPERATOR_IMG}
 LABEL devicefinder=${DEVICEFINDER_IMAGE}
 LABEL console-plugin=${CONSOLE_PLUGIN_IMAGE}

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -10,6 +10,8 @@ RUN make build-devicefinder
 # Change this once ubi10 moves out of beta
 FROM registry.redhat.io/ubi10-beta/ubi:latest
 
+ARG VERSION=1.0
+
 COPY --from=builder /workspace/_output/bin/devicefinder /usr/bin/
 
 ENTRYPOINT ["/usr/bin/devicefinder"]
@@ -23,8 +25,8 @@ LABEL \
     distribution-scope="public" \
     name="openshift-fusion-access-devicefinder" \
     summary="Device Finder" \
-    release="v1.0" \
-    version="v1.0" \
+    release="v${VERSION}" \
+    version="v${VERSION}" \
     maintainer="Red Hat jgil@redhat.com" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
     vendor="Red Hat, Inc." \

--- a/templates/must-gather.Dockerfile.template
+++ b/templates/must-gather.Dockerfile.template
@@ -1,5 +1,7 @@
 FROM registry.redhat.io/multicluster-engine/must-gather-rhel9:v2.8 AS builder
 
+ARG VERSION=1.0
+
 # Copy our scripts
 COPY collection-scripts/* /usr/bin/
 
@@ -13,8 +15,8 @@ LABEL \
     distribution-scope="public" \
     name="openshift-fusion-access-must-gather-rhel9" \
     vendor="Red Hat, Inc." \
-    version="v1.0" \
-    release="v1.0" \
+    release="v${VERSION}" \
+    version="v${VERSION}" \
     summary="Must gather image" \
     description="" \
     maintainer="Red Hat jgil@redhat.com" \

--- a/templates/operator.Dockerfile.template
+++ b/templates/operator.Dockerfile.template
@@ -1,3 +1,4 @@
+
 ARG TARGETARCH=amd64
 
 FROM --platform=linux/$TARGETARCH brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 AS builder
@@ -26,7 +27,7 @@ RUN mkdir licenses
 COPY LICENSE licenses/
 
 # Build
-RUN --mount=type=secret,id=pull hack/build.sh
+RUN --mount=type=secret,id=pull export SECRET_NAME=${SECRET_NAME}; hack/build.sh
 
 # UBI is larger (158Mb vs. 56Mb) but approved by RH
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
@@ -35,6 +36,10 @@ COPY --from=builder /workspace/files/ /files/
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/licenses/ /licenses/
 USER 65532:65532
+
+ARG VERSION=1.0
+
+
 
 ENTRYPOINT ["/manager"]
 
@@ -47,8 +52,8 @@ LABEL \
     distribution-scope="public" \
     name="openshift-fusion-access-controller" \
     summary="Controller" \
-    release="v1.0" \
-    version="v1.0" \
+    release="v${VERSION}" \
+    version="v${VERSION}" \
     maintainer="Red Hat jgil@redhat.com" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
     vendor="Red Hat, Inc." \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -272,6 +272,8 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/rogpeppe/go-internal v1.13.1
+## explicit; go 1.22
 # github.com/spf13/cobra v1.9.1
 ## explicit; go 1.15
 github.com/spf13/cobra


### PR DESCRIPTION
## Summary by Sourcery

Implement a dynamic Dockerfile generation system using templates and update Konflux CI pipelines to support on-the-fly Dockerfile creation for different components

New Features:
- Introduce template-based Dockerfile generation for operator, devicefinder, and must-gather components

Enhancements:
- Add Makefile targets to generate Dockerfiles dynamically using envsubst
- Update build processes to use dynamically generated Dockerfiles

CI:
- Add generate-dockerfile task to Konflux CI pipelines for operator, devicefinder, and must-gather
- Modify pipeline dependency flow to include Dockerfile generation step

Chores:
- Create a new script to generate Dockerfiles from templates
- Update Dockerfile templates to use dynamic version labeling