### PR TITLE
Fix dockerfile name in controller's push

### DIFF
--- a/.tekton/controller-rhel9-operator-1-0-push.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/storage-scale-releng-tenant/controller-rhel9-operator:{{revision}}
   - name: dockerfile
-    value: Dockerfile
+    value: operator.Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Change the dockerfile parameter from 'Dockerfile' to 'operator.Dockerfile' in the Tekton pipeline specification