### PR TITLE
Add secret watch and any hard coded pull secret

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -528,3 +528,18 @@ rules:
   - patch
   - update
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-role
+  namespace: openshift-fusion-access
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -24,14 +25,19 @@ import (
 
 	mfc "github.com/manifestival/controller-runtime-client"
 	"github.com/manifestival/manifestival"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	fusionv1alpha "github.com/openshift-storage-scale/openshift-fusion-access-operator/api/v1alpha1"
@@ -55,6 +61,8 @@ type FusionAccessReconciler struct {
 //+kubebuilder:rbac:groups=fusion.storage.openshift.io,resources=fusionaccesses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fusion.storage.openshift.io,resources=fusionaccesses/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=fusion.storage.openshift.io,resources=fusionaccesses/finalizers,verbs=update
+
+//+kubebuilder:rbac:groups="",namespace=openshift-fusion-access,resources=secrets,verbs=get;list;watch
 
 // Below rules are inserted via `make rbac-generate` automatically
 // IBM_RBAC_MARKER_START
@@ -314,7 +322,9 @@ func (r *FusionAccessReconciler) Reconcile(
 	// patching the global pull secret
 	secret, err := getPullSecretContent(FUSIONPULLSECRETNAME, ns, ctx, r.fullClient)
 	if err != nil {
-		log.Log.Info("Pull secret not found, skipping entitlement secret creation")
+		log.Log.Info(
+			"Pull secret not found, skipping entitlement secret creation, we will watch this secret",
+		)
 	} else {
 		// Create entitlement secrets
 		err = updateEntitlementPullSecrets(secret, ctx, r.fullClient)
@@ -379,7 +389,94 @@ func (r *FusionAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&fusionv1alpha.FusionAccess{}).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.getPullSecretSelector),
+			isItOurPullSecret(),
+		).
 		Complete(r)
+}
+
+func (r *FusionAccessReconciler) getPullSecretSelector(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	ns, err := utils.GetDeploymentNamespace()
+	if err != nil {
+		return []reconcile.Request{}
+	}
+	if _, err := getPullSecretContent(FUSIONPULLSECRETNAME, ns, ctx, r.fullClient); err != nil {
+		// The secret in the namespace is not there yet
+		return []reconcile.Request{}
+	}
+	fusionAccessList := &fusionv1alpha.FusionAccessList{}
+	if err := r.Client.List(ctx, fusionAccessList, client.InNamespace(ns)); err != nil {
+		return nil
+	}
+	// We enforce a single fusionAccess instance via webhooks
+	req := reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(&fusionAccessList.Items[0]),
+	}
+	log.Log.Info("Enqueueing request for", "request", req)
+	return []reconcile.Request{req}
+}
+
+// isItOurPullSecret returns true for Create or changed Update events
+func isItOurPullSecret() builder.WatchesOption {
+	return builder.WithPredicates(predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			ns, err := utils.GetDeploymentNamespace()
+			if err != nil {
+				return false
+			}
+			newSecret, ok := e.Object.DeepCopyObject().(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			return checkPullSecret(newSecret, ns)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			ns, err := utils.GetDeploymentNamespace()
+			if err != nil {
+				return false
+			}
+			newSecret, ok := e.ObjectNew.DeepCopyObject().(*corev1.Secret)
+			if !ok {
+				return false
+			}
+			oldSecret, ok := e.ObjectOld.DeepCopyObject().(*corev1.Secret)
+			if !ok {
+				return true
+			}
+			if !checkPullSecret(newSecret, ns) {
+				return false
+			}
+			return !bytes.Equal(
+				oldSecret.Data[".dockerconfigjson"],
+				newSecret.Data[".dockerconfigjson"],
+			)
+
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	})
+}
+
+func checkPullSecret(secret *corev1.Secret, ns string) bool {
+	if secret.Type != "kubernetes.io/dockerconfigjson" {
+		return false
+	}
+	if secret.Name != FUSIONPULLSECRETNAME {
+		return false
+	}
+	if secret.Namespace != ns {
+		return false
+	}
+	return true
 }
 
 // func (r *FusionAccessReconciler) finalizeFusionAccess(reqLogger logr.Logger, sc *v1alpha1.FusionAccess) error {

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -399,7 +399,7 @@ func (r *FusionAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *FusionAccessReconciler) getPullSecretSelector(
 	ctx context.Context,
-	obj client.Object,
+	_ client.Object,
 ) []reconcile.Request {
 	ns, err := utils.GetDeploymentNamespace()
 	if err != nil {
@@ -410,7 +410,7 @@ func (r *FusionAccessReconciler) getPullSecretSelector(
 		return []reconcile.Request{}
 	}
 	fusionAccessList := &fusionv1alpha.FusionAccessList{}
-	if err := r.Client.List(ctx, fusionAccessList, client.InNamespace(ns)); err != nil {
+	if err := r.List(ctx, fusionAccessList, client.InNamespace(ns)); err != nil {
 		return nil
 	}
 	// We enforce a single fusionAccess instance via webhooks
@@ -455,12 +455,11 @@ func isItOurPullSecret() builder.WatchesOption {
 				oldSecret.Data[".dockerconfigjson"],
 				newSecret.Data[".dockerconfigjson"],
 			)
-
 		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
+		DeleteFunc: func(_ event.DeleteEvent) bool {
 			return false
 		},
-		GenericFunc: func(e event.GenericEvent) bool {
+		GenericFunc: func(_ event.GenericEvent) bool {
 			return false
 		},
 	})

--- a/internal/controller/fusionaccess_controller_test.go
+++ b/internal/controller/fusionaccess_controller_test.go
@@ -107,6 +107,61 @@ var _ = Describe("FusionAccess Controller", func() {
 	})
 })
 
+var _ = Describe("checkPullSecret", func() {
+	const (
+		expectedName      = "fusion-pullsecret"
+		expectedNamespace = "default"
+	)
+
+	It("returns true for a valid pull secret", func() {
+		secret := &corev1.Secret{
+			Type: corev1.SecretTypeDockerConfigJson,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      expectedName,
+				Namespace: expectedNamespace,
+			},
+		}
+
+		Expect(checkPullSecret(secret, expectedNamespace)).To(BeTrue())
+	})
+
+	It("returns false if secret type is incorrect", func() {
+		secret := &corev1.Secret{
+			Type: corev1.SecretTypeOpaque,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      expectedName,
+				Namespace: expectedNamespace,
+			},
+		}
+
+		Expect(checkPullSecret(secret, expectedNamespace)).To(BeFalse())
+	})
+
+	It("returns false if secret name is incorrect", func() {
+		secret := &corev1.Secret{
+			Type: corev1.SecretTypeDockerConfigJson,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-name",
+				Namespace: expectedNamespace,
+			},
+		}
+
+		Expect(checkPullSecret(secret, expectedNamespace)).To(BeFalse())
+	})
+
+	It("returns false if secret namespace is incorrect", func() {
+		secret := &corev1.Secret{
+			Type: corev1.SecretTypeDockerConfigJson,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      expectedName,
+				Namespace: "other-namespace",
+			},
+		}
+
+		Expect(checkPullSecret(secret, expectedNamespace)).To(BeFalse())
+	})
+})
+
 func newNamespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 }

--- a/internal/controller/quay.go
+++ b/internal/controller/quay.go
@@ -1,8 +1,0 @@
-package controller
-
-import (
-	_ "embed"
-)
-
-//go:embed pull.txt
-var pull string

--- a/internal/controller/secret.go
+++ b/internal/controller/secret.go
@@ -1,9 +1,27 @@
 package controller
 
 import (
+	"context"
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const FUSIONPULLSECRETNAME = "fusion-pullsecret"
+const IBMENTITLEMENTNAME = "ibm-entitlement-key"
+
+func IbmEntitlementSecrets() []string {
+	return []string{
+		"ibm-spectrum-scale",
+		"ibm-spectrum-scale-dns",
+		"ibm-spectrum-scale-csi",
+		"ibm-spectrum-scale-operator",
+	}
+}
 
 func newSecret(name, namespace string, secret map[string][]byte, secretType corev1.SecretType, labels map[string]string) *corev1.Secret {
 	k8sSecret := &corev1.Secret{
@@ -16,4 +34,61 @@ func newSecret(name, namespace string, secret map[string][]byte, secretType core
 		Type: secretType,
 	}
 	return k8sSecret
+}
+
+func getPullSecretContent(name, namespace string, ctx context.Context, full kubernetes.Interface) ([]byte, error) {
+	secret, err := full.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if secret.Type != corev1.SecretTypeDockerConfigJson {
+		return nil, fmt.Errorf("secret %s is not of type %s", name, corev1.SecretTypeDockerConfigJson)
+	}
+	if secret.Data == nil {
+		return nil, fmt.Errorf("secret %s has no data", name)
+	}
+	secData, ok := secret.Data[".dockerconfigjson"]
+	if !ok {
+		return nil, fmt.Errorf("secret %s does not contain .dockerconfigjson", name)
+	}
+	return secData, nil
+}
+
+func updateEntitlementPullSecrets(secret []byte, ctx context.Context, full kubernetes.Interface) error {
+	// Create secrets in IBM namespaces to pull images from quay
+	secretData := map[string][]byte{
+		".dockerconfigjson": []byte(secret),
+	}
+
+	destSecretName := IBMENTITLEMENTNAME //nolint:gosec
+
+	for _, destNamespace := range IbmEntitlementSecrets() {
+		ibmPullSecret := newSecret(
+			destSecretName,
+			destNamespace,
+			secretData,
+			"kubernetes.io/dockerconfigjson",
+			nil,
+		)
+		_, err := full.CoreV1().Secrets(destNamespace).Get(ctx, destSecretName, metav1.GetOptions{})
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				// Resource does not exist, create it
+				_, err := full.CoreV1().Secrets(destNamespace).Create(context.TODO(), ibmPullSecret, metav1.CreateOptions{})
+				if err != nil {
+					return err
+				}
+				log.Log.Info(fmt.Sprintf("Created Secret %s in ns %s", destSecretName, destNamespace))
+				continue
+			}
+			return err
+		}
+		// The destination secret already exists so we upate it and return an error if they were different so the reconcile loop can restart
+		_, err = full.CoreV1().Secrets(destNamespace).Update(context.TODO(), ibmPullSecret, metav1.UpdateOptions{})
+		if err == nil {
+			log.Log.Info(fmt.Sprintf("Updated Secret %s in ns %s", destSecretName, destNamespace))
+			continue
+		}
+	}
+	return nil
 }

--- a/internal/controller/secret.go
+++ b/internal/controller/secret.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const FUSIONPULLSECRETNAME = "fusion-pullsecret"
+const FUSIONPULLSECRETNAME = "fusion-pullsecret" //nolint:gosec
 const IBMENTITLEMENTNAME = "ibm-entitlement-key"
 
 func IbmEntitlementSecrets() []string {
@@ -57,7 +57,7 @@ func getPullSecretContent(name, namespace string, ctx context.Context, full kube
 func updateEntitlementPullSecrets(secret []byte, ctx context.Context, full kubernetes.Interface) error {
 	// Create secrets in IBM namespaces to pull images from quay
 	secretData := map[string][]byte{
-		".dockerconfigjson": []byte(secret),
+		".dockerconfigjson": secret,
 	}
 
 	destSecretName := IBMENTITLEMENTNAME //nolint:gosec

--- a/internal/controller/secret.go
+++ b/internal/controller/secret.go
@@ -36,7 +36,7 @@ func newSecret(name, namespace string, secret map[string][]byte, secretType core
 	return k8sSecret
 }
 
-func getPullSecretContent(name, namespace string, ctx context.Context, full kubernetes.Interface) ([]byte, error) {
+func getPullSecretContent(name, namespace string, ctx context.Context, full kubernetes.Interface) ([]byte, error) { //nolint:unparam
 	secret, err := full.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/internal/controller/secret_test.go
+++ b/internal/controller/secret_test.go
@@ -51,7 +51,7 @@ var _ = Describe("FusionAccess Utilities", func() {
 	})
 
 	Describe("getPullSecretContent", func() {
-		const secretName = "fusion-pullsecret"
+		const secretName = "fusion-pullsecret" //nolint:gosec
 
 		It("should return error if secret doesn't exist", func() {
 			_, err := getPullSecretContent(secretName, "default", ctx, clientset)
@@ -61,7 +61,7 @@ var _ = Describe("FusionAccess Utilities", func() {
 
 		It("should return error for wrong secret type", func() {
 			secret := newSecret(secretName, "default", map[string][]byte{}, corev1.SecretTypeOpaque, nil)
-			clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+			_, _ = clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
 
 			_, err := getPullSecretContent(secretName, "default", ctx, clientset)
 			Expect(err).To(MatchError(ContainSubstring("is not of type")))
@@ -69,7 +69,7 @@ var _ = Describe("FusionAccess Utilities", func() {
 
 		It("should return error if .dockerconfigjson is missing", func() {
 			secret := newSecret(secretName, "default", map[string][]byte{}, corev1.SecretTypeDockerConfigJson, nil)
-			clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+			_, _ = clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
 
 			_, err := getPullSecretContent(secretName, "default", ctx, clientset)
 			Expect(err).To(MatchError(ContainSubstring("does not contain .dockerconfigjson")))
@@ -80,7 +80,7 @@ var _ = Describe("FusionAccess Utilities", func() {
 				".dockerconfigjson": []byte("my-secret-data"),
 			}
 			secret := newSecret(secretName, "default", data, corev1.SecretTypeDockerConfigJson, nil)
-			clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+			_, _ = clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
 
 			content, err := getPullSecretContent(secretName, "default", ctx, clientset)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/secret_test.go
+++ b/internal/controller/secret_test.go
@@ -1,0 +1,129 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("FusionAccess Utilities", func() {
+	var (
+		clientset kubernetes.Interface
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		clientset = fake.NewSimpleClientset()
+		ctx = context.TODO()
+	})
+
+	Describe("IbmEntitlementSecrets", func() {
+		It("should return the correct IBM namespaces", func() {
+			names := IbmEntitlementSecrets()
+			Expect(names).To(ConsistOf(
+				"ibm-spectrum-scale",
+				"ibm-spectrum-scale-dns",
+				"ibm-spectrum-scale-csi",
+				"ibm-spectrum-scale-operator",
+			))
+		})
+	})
+
+	Describe("newSecret", func() {
+		It("should return a properly formed Secret", func() {
+			data := map[string][]byte{"foo": []byte("bar")}
+			labels := map[string]string{"app": "test"}
+			sec := newSecret("my-secret", "default", data, corev1.SecretTypeOpaque, labels)
+
+			Expect(sec.Name).To(Equal("my-secret"))
+			Expect(sec.Namespace).To(Equal("default"))
+			Expect(sec.Data["foo"]).To(Equal([]byte("bar")))
+			Expect(sec.Labels["app"]).To(Equal("test"))
+			Expect(sec.Type).To(Equal(corev1.SecretTypeOpaque))
+		})
+	})
+
+	Describe("getPullSecretContent", func() {
+		const secretName = "fusion-pullsecret"
+
+		It("should return error if secret doesn't exist", func() {
+			_, err := getPullSecretContent(secretName, "default", ctx, clientset)
+			Expect(err).To(HaveOccurred())
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should return error for wrong secret type", func() {
+			secret := newSecret(secretName, "default", map[string][]byte{}, corev1.SecretTypeOpaque, nil)
+			clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+
+			_, err := getPullSecretContent(secretName, "default", ctx, clientset)
+			Expect(err).To(MatchError(ContainSubstring("is not of type")))
+		})
+
+		It("should return error if .dockerconfigjson is missing", func() {
+			secret := newSecret(secretName, "default", map[string][]byte{}, corev1.SecretTypeDockerConfigJson, nil)
+			clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+
+			_, err := getPullSecretContent(secretName, "default", ctx, clientset)
+			Expect(err).To(MatchError(ContainSubstring("does not contain .dockerconfigjson")))
+		})
+
+		It("should return secret content if valid", func() {
+			data := map[string][]byte{
+				".dockerconfigjson": []byte("my-secret-data"),
+			}
+			secret := newSecret(secretName, "default", data, corev1.SecretTypeDockerConfigJson, nil)
+			clientset.CoreV1().Secrets("default").Create(ctx, secret, metav1.CreateOptions{})
+
+			content, err := getPullSecretContent(secretName, "default", ctx, clientset)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(content).To(Equal([]byte("my-secret-data")))
+		})
+	})
+
+	Describe("updateEntitlementPullSecrets", func() {
+		var secretData []byte
+
+		BeforeEach(func() {
+			secretData = []byte("test-dockerconfigjson")
+		})
+
+		It("creates secrets in all IBM namespaces if not present", func() {
+			err := updateEntitlementPullSecrets(secretData, ctx, clientset)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, ns := range IbmEntitlementSecrets() {
+				sec, err := clientset.CoreV1().Secrets(ns).Get(ctx, IBMENTITLEMENTNAME, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sec.Data[".dockerconfigjson"]).To(Equal(secretData))
+			}
+		})
+
+		It("updates existing secrets", func() {
+			// Create dummy existing secrets with wrong data
+			for _, ns := range IbmEntitlementSecrets() {
+				dummy := newSecret(IBMENTITLEMENTNAME, ns, map[string][]byte{
+					".dockerconfigjson": []byte("old-data"),
+				}, corev1.SecretTypeDockerConfigJson, nil)
+				_, err := clientset.CoreV1().Secrets(ns).Create(ctx, dummy, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			err := updateEntitlementPullSecrets(secretData, ctx, clientset)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, ns := range IbmEntitlementSecrets() {
+				sec, err := clientset.CoreV1().Secrets(ns).Get(ctx, IBMENTITLEMENTNAME, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sec.Data[".dockerconfigjson"]).To(Equal(secretData))
+			}
+		})
+	})
+})


### PR DESCRIPTION
- **Introduce a fusion-pullsecret**
- **Fix some linting**
- **Drop old pull secret**
- **Add watch to the pull secret**

## Summary by Sourcery

Enhance secret management for IBM Fusion Access by introducing a new pull secret mechanism and improving secret handling across namespaces

New Features:
- Add watch mechanism for fusion pull secrets to dynamically manage image pull credentials

Enhancements:
- Refactor secret creation and management logic to be more flexible and namespace-aware
- Improve error handling and logging for secret operations

Chores:
- Remove unused quay.go file
- Consolidate secret-related functions in secret.go