### PR TITLE
Hide storagedevicediscovery from UI for now

### DIFF
--- a/api/v1alpha1/fusionaccess_types.go
+++ b/api/v1alpha1/fusionaccess_types.go
@@ -34,7 +34,7 @@ type FusionAccessSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:v5.2.2.1","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.rc1"}
 	IbmCnsaVersion CNSAVersions `json:"ibm_cnsa_version,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	LocalVolumeDiscovery StorageDeviceDiscovery `json:"storagedevicediscovery,omitempty"`
 }
 type StorageDeviceDiscovery struct {


### PR DESCRIPTION
We might enable it at a later stage, but for now we want it active
all the time

Hidden attribute is documented here:
https://github.com/openshift/console/blob/main/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md#21-hidden
