### PR TITLE
Add the exact variable to substitute when doing the envsubst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ generate-dockefile-must-gather:
 # Generate Dockerfile using the template. It uses envsubst to replace the value of the version label in the container
 .PHONY: generate-dockerfile-console-plugin
 generate-dockerfile-console-plugin:
-	envsubst < templates/console-plugin.Dockerfile.template > $(CONSOLE_PLUGIN_DOCKERFILE)
+	envsubst '$${VERSION}' < templates/console-plugin.Dockerfile.template > $(CONSOLE_PLUGIN_DOCKERFILE)
 
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.


### PR DESCRIPTION
The console-plugin dockerfile template has environment variable which we do
not want substitued during runnning envsubst. We pass in the variable
escaped in the Makefile.

## Summary by Sourcery

Enhancements:
- Limit environment variable substitution to only the VERSION variable when generating the console-plugin Dockerfile