### PR TITLE
Fixes the role column not displaying properly

### DIFF
--- a/console/src/selectors/kubernetes/1.30/IoK8sApiCoreV1Node.ts
+++ b/console/src/selectors/kubernetes/1.30/IoK8sApiCoreV1Node.ts
@@ -18,6 +18,7 @@ export const getRole = (node: IoK8sApiCoreV1Node): NodeRole => {
   let role: NodeRole = VALUE_NOT_AVAILABLE;
   switch (true) {
     case hasLabel(node, "node-role.kubernetes.io/worker="):
+      role = "worker";
       break;
     case hasLabel(node, "node-role.kubernetes.io/master="):
       role = "master";


### PR DESCRIPTION
Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Corrected the logic for determining a worker node's role, ensuring the 'worker' role is properly displayed when the corresponding label is present