### PR TITLE
Remove need to use yaml to store nudges and use env variable instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 export VERSION ?= $(shell cat VERSION.txt)
 
 
-OPERATOR_DOCKERFILE ?= Dockerfile
+OPERATOR_DOCKERFILE ?= operator.Dockerfile
 DEVICEFINDER_DOCKERFILE ?= devicefinder.Dockerfile
 MUST_GATHER_DOCKERFILE ?= must-gather.Dockerfile
 CONSOLE_PLUGIN_DOCKERFILE ?= console-plugin.Dockerfile

--- a/nudges/consolePlugin.env
+++ b/nudges/consolePlugin.env
@@ -1,0 +1,1 @@
+CONSOLE_PLUGIN_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-console-plugin-rhel9@sha256:322a29d5ecf8bd4e72ef811dd34ed4493a49e16306e98b1377c3d26e5fc53018"

--- a/nudges/consolePlugin.imagePullSpec.yaml
+++ b/nudges/consolePlugin.imagePullSpec.yaml
@@ -1,2 +1,0 @@
-raw: |
-  export CONSOLE_PLUGIN_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-console-plugin-rhel9@sha256:322a29d5ecf8bd4e72ef811dd34ed4493a49e16306e98b1377c3d26e5fc53018"

--- a/nudges/deviceFinder.env
+++ b/nudges/deviceFinder.env
@@ -1,0 +1,1 @@
+DEVICEFINDER_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-devicefinder-rhel9@sha256:7cf69c9791833f31dcaaa0a41191bfa73e2faf2bc4c39761174f7bc104bd07ab"

--- a/nudges/deviceFinder.imagePullSpec.yaml
+++ b/nudges/deviceFinder.imagePullSpec.yaml
@@ -1,2 +1,0 @@
-raw: |
-  export DEVICEFINDER_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-devicefinder-rhel9@sha256:7cf69c9791833f31dcaaa0a41191bfa73e2faf2bc4c39761174f7bc104bd07ab"

--- a/nudges/mustGather.env
+++ b/nudges/mustGather.env
@@ -1,0 +1,1 @@
+MUST_GATHER_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d"

--- a/nudges/mustGather.imagePullSpec.yaml
+++ b/nudges/mustGather.imagePullSpec.yaml
@@ -1,2 +1,0 @@
-raw: |
-  export MUST_GATHER_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d"

--- a/nudges/operator.env
+++ b/nudges/operator.env
@@ -1,0 +1,1 @@
+OPERATOR_IMG="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-rhel9-operator@sha256:86ba3474ccb82bbbb1020a8ada3921bd3a7ad71fd293e7f8f769f82f09f4520a"

--- a/nudges/operator.imagePullSpec.yaml
+++ b/nudges/operator.imagePullSpec.yaml
@@ -1,2 +1,0 @@
-raw: |
-  export OPERATOR_IMG="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-rhel9-operator@sha256:86ba3474ccb82bbbb1020a8ada3921bd3a7ad71fd293e7f8f769f82f09f4520a"

--- a/scripts/generate-bundle-for-konflux.sh
+++ b/scripts/generate-bundle-for-konflux.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Source the environment values that contain the component image pullspecs coming from the  nudges
-for file in nudges/*.imagePullSpec.yaml
-do $(cat $file | tail -n+2 )
+for file in nudges/*.env
+do export $(cat $file)
 done
 
 # Expose the operator's version as an env variable to be used when building the operator-sdk's bundle


### PR DESCRIPTION
## Summary by Sourcery

Replace YAML-based image pull specification storage with environment variable files

Enhancements:
- Modify script to read image pull specifications from .env files instead of YAML files

Chores:
- Remove existing YAML files for image pull specifications
- Create corresponding .env files for image pull specifications