### PR TITLE
Add pull container status

### DIFF
--- a/api/v1alpha1/fusionaccess_types.go
+++ b/api/v1alpha1/fusionaccess_types.go
@@ -25,6 +25,14 @@ import (
 // +kubebuilder:validation:Enum=v5.2.2.1;v5.2.3.0.rc1
 type CNSAVersions string
 
+type ExternalImagePullStatus int
+
+const (
+	CheckNotRun ExternalImagePullStatus = iota
+	CheckSuccess
+	CheckFailed
+)
+
 // FusionAccessSpec defines the desired state of FusionAccess
 type FusionAccessSpec struct {
 	// NOTE(bandini): If you change anything in the following three lines you need to update
@@ -53,6 +61,10 @@ type FusionAccessStatus struct {
 	// observedGeneration is the last generation change the operator has dealt with
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Show the status of pulling an external test image
+	ExternalImagePullStatus ExternalImagePullStatus `json:"externalImagePullStatus,omitempty"`
+	// Show the error in case of failure of pulling external image
+	ExternalImagePullError string `json:"externalImagePullError,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,10 +148,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controller.FusionAccessReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	if err = (controller.NewFusionAccessReconciler(mgr.GetClient(), mgr.GetScheme())).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "FusionAccess")
 		os.Exit(1)
 	}

--- a/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
+++ b/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
@@ -98,6 +98,13 @@ spec:
                   - type
                   type: object
                 type: array
+              externalImagePullError:
+                description: Show the error in case of failure of pulling external
+                  image
+                type: string
+              externalImagePullStatus:
+                description: Show the status of pulling an external test image
+                type: integer
               observedGeneration:
                 description: observedGeneration is the last generation change the
                   operator has dealt with

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -352,12 +352,15 @@ func (r *FusionAccessReconciler) Reconcile(
 	if fusionaccess.Status.ExternalImagePullStatus == fusionv1alpha1.CheckNotRun {
 		testImage, err := utils.GetExternalTestImage(string(fusionaccess.Spec.IbmCnsaVersion))
 		if err != nil {
+			log.Log.Error(err, "Could not figure out test image", "testImage", testImage)
 			return ctrl.Result{}, err
 		}
 		ok, err := r.CanPullImage(ctx, r.fullClient, ns, testImage)
 		if ok {
+			log.Log.Info("Image pull test succeeded", "ns", ns, "testImage", testImage)
 			fusionaccess.Status.ExternalImagePullStatus = fusionv1alpha1.CheckSuccess
 		} else {
+			log.Log.Error(err, "Image pull test failed", "ns", ns, "testImage", testImage)
 			fusionaccess.Status.ExternalImagePullStatus = fusionv1alpha1.CheckFailed
 			fusionaccess.Status.ExternalImagePullError = err.Error()
 		}

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -348,8 +348,9 @@ func (r *FusionAccessReconciler) Reconcile(
 		log.Log.Info("Entitlement secrets created")
 	}
 
-	// Check if can pull the image if we have not already
-	if fusionaccess.Status.ExternalImagePullStatus == fusionv1alpha1.CheckNotRun {
+	// Check if can pull the image if we have not already or if it failed previously
+	if fusionaccess.Status.ExternalImagePullStatus == fusionv1alpha1.CheckNotRun ||
+		fusionaccess.Status.ExternalImagePullStatus == fusionv1alpha1.CheckFailed {
 		testImage, err := utils.GetExternalTestImage(string(fusionaccess.Spec.IbmCnsaVersion))
 		if err != nil {
 			log.Log.Error(err, "Could not figure out test image", "testImage", testImage)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -17,12 +17,26 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"path"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	configv1 "github.com/openshift/api/config/v1"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	CheckPodMaxImagePullTimeout = 180 * time.Second
+	CheckPodPullInterval        = 2 * time.Second
+	CheckPodName                = "image-check-fusion-access"
+	CheckPodContainerName       = "check"
 )
 
 // Taken from https://www.ibm.com/docs/en/scalecontainernative/5.2.2?topic=planning-software-requirements
@@ -36,21 +50,111 @@ type FusionAccessData struct {
 
 // The dict key is the IBM Fusion Access Container Native version
 var storageScaleTable = map[string]FusionAccessData{
-	"5.1.5.0": {"2.7.0", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "29.00", []string{"4.9", "4.10", "4.11"}},
-	"5.1.6.0": {"2.8.0", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "30.00", []string{"4.9", "4.10", "4.11"}},
-	"5.1.7.0": {"2.9.0", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "31.00", []string{"4.10", "4.11", "4.12"}},
-	"5.1.9.1": {"2.10.0", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "33.00", []string{"4.12", "4.13", "4.14"}},
-	"5.1.9.3": {"2.10.1", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "33.00", []string{"4.12", "4.13", "4.14"}},
-	"5.1.9.4": {"2.10.2", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "33.00", []string{"4.12", "4.13", "4.14"}},
-	"5.1.9.5": {"2.10.3", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "33.00", []string{"4.12", "4.13", "4.14"}},
-	"5.1.9.6": {"2.10.4", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "33.00", []string{"4.12", "4.13", "4.14"}},
-	"5.1.9.7": {"2.10.5", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "33.00", []string{"4.12", "4.13", "4.14"}},
-	"5.2.0.0": {"2.11.0", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "34.00", []string{"4.13", "4.14", "4.15"}},
-	"5.2.0.1": {"2.11.1", []string{"x86_64", "ppc64le", "s390x"}, "5.1.3.0+", "34.00", []string{"4.13", "4.14", "4.15"}},
-	"5.2.1.0": {"2.12.0", []string{"x86_64", "ppc64le", "s390x"}, "5.1.9.0+", "35.00", []string{"4.14", "4.15", "4.16"}},
-	"5.2.1.1": {"2.12.1", []string{"x86_64", "ppc64le", "s390x"}, "5.1.9.0+", "35.00", []string{"4.14", "4.15", "4.16"}},
-	"5.2.2.0": {"2.13.0", []string{"x86_64", "ppc64le", "s390x"}, "5.1.9.0+", "36.00", []string{"4.15", "4.16", "4.17"}},
-	"5.2.2.1": {"2.13.1", []string{"x86_64", "ppc64le", "s390x"}, "5.1.9.0+", "36.00", []string{"4.15", "4.16", "4.17", "4.18"}},
+	"5.1.5.0": {
+		"2.7.0",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"29.00",
+		[]string{"4.9", "4.10", "4.11"},
+	},
+	"5.1.6.0": {
+		"2.8.0",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"30.00",
+		[]string{"4.9", "4.10", "4.11"},
+	},
+	"5.1.7.0": {
+		"2.9.0",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"31.00",
+		[]string{"4.10", "4.11", "4.12"},
+	},
+	"5.1.9.1": {
+		"2.10.0",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"33.00",
+		[]string{"4.12", "4.13", "4.14"},
+	},
+	"5.1.9.3": {
+		"2.10.1",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"33.00",
+		[]string{"4.12", "4.13", "4.14"},
+	},
+	"5.1.9.4": {
+		"2.10.2",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"33.00",
+		[]string{"4.12", "4.13", "4.14"},
+	},
+	"5.1.9.5": {
+		"2.10.3",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"33.00",
+		[]string{"4.12", "4.13", "4.14"},
+	},
+	"5.1.9.6": {
+		"2.10.4",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"33.00",
+		[]string{"4.12", "4.13", "4.14"},
+	},
+	"5.1.9.7": {
+		"2.10.5",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"33.00",
+		[]string{"4.12", "4.13", "4.14"},
+	},
+	"5.2.0.0": {
+		"2.11.0",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"34.00",
+		[]string{"4.13", "4.14", "4.15"},
+	},
+	"5.2.0.1": {
+		"2.11.1",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.3.0+",
+		"34.00",
+		[]string{"4.13", "4.14", "4.15"},
+	},
+	"5.2.1.0": {
+		"2.12.0",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.9.0+",
+		"35.00",
+		[]string{"4.14", "4.15", "4.16"},
+	},
+	"5.2.1.1": {
+		"2.12.1",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.9.0+",
+		"35.00",
+		[]string{"4.14", "4.15", "4.16"},
+	},
+	"5.2.2.0": {
+		"2.13.0",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.9.0+",
+		"36.00",
+		[]string{"4.15", "4.16", "4.17"},
+	},
+	"5.2.2.1": {
+		"2.13.1",
+		[]string{"x86_64", "ppc64le", "s390x"},
+		"5.1.9.0+",
+		"36.00",
+		[]string{"4.15", "4.16", "4.17", "4.18"},
+	},
 }
 
 func IsOpenShiftSupported(ibmFusionAccessVersion string, openShiftVersion semver.Version) bool {
@@ -129,4 +233,198 @@ func GetDeploymentNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", deployNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+type ConfigMap struct {
+	Kind     string            `yaml:"kind"`
+	Metadata map[string]any    `yaml:"metadata"`
+	Data     map[string]string `yaml:"data"`
+}
+
+type ControllerManagerConfig struct {
+	Images map[string]string `yaml:"images"`
+}
+
+// ParseYAMLAndExtractCoreInit takes multi-doc YAML and returns coreInit value
+func ParseYAMLAndExtractTestImage(yamlContent string) (string, error) {
+	decoder := yaml.NewDecoder(strings.NewReader(yamlContent))
+	for {
+		var node yaml.Node
+		if err := decoder.Decode(&node); err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return "", fmt.Errorf("failed to decode YAML: %w", err)
+		}
+		var kindNode struct {
+			Kind     string `yaml:"kind"`
+			Metadata struct {
+				Name string `yaml:"name"`
+			} `yaml:"metadata"`
+		}
+		if err := node.Decode(&kindNode); err != nil {
+			continue // not a valid K8s resource, skip
+		}
+		if kindNode.Kind == "ConfigMap" &&
+			kindNode.Metadata.Name == "ibm-spectrum-scale-manager-config" {
+			var cm ConfigMap
+			if err := node.Decode(&cm); err != nil {
+				return "", fmt.Errorf("failed to decode ConfigMap: %w", err)
+			}
+
+			embeddedYAML, ok := cm.Data["controller_manager_config.yaml"]
+			if !ok {
+				return "", fmt.Errorf("controller_manager_config.yaml not found in ConfigMap")
+			}
+
+			var config ControllerManagerConfig
+			if err := yaml.Unmarshal([]byte(embeddedYAML), &config); err != nil {
+				return "", fmt.Errorf("failed to parse embedded YAML: %w", err)
+			}
+
+			coreInit, ok := config.Images["coreInit"]
+			if !ok {
+				return "", fmt.Errorf("coreInit not found in images")
+			}
+
+			return coreInit, nil
+		}
+	}
+
+	return "", fmt.Errorf("ConfigMap object in install yaml not found")
+}
+
+// GetExternalTestImage returns the image to be used for testing external image pull.
+// FIXME(bandini): For now this is hardcoded, we should make sure this is
+func GetExternalTestImage(cnsaVersion string) (string, error) {
+	manifestFile, err := GetInstallPath(cnsaVersion)
+	if err != nil {
+		return "", err
+	}
+	manifest, err := os.ReadFile(manifestFile)
+	if err != nil {
+		return "", err
+	}
+
+	image, err := ParseYAMLAndExtractTestImage(string(manifest))
+	if err != nil {
+		return "", err
+	}
+	return image, nil
+}
+
+// CreateImageCheckPod creates a pod with the specified image and returns its name.
+func CreateImageCheckPod(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace, image string,
+) (string, error) {
+	existingPod, err := client.CoreV1().Pods(namespace).Get(ctx, CheckPodName, metav1.GetOptions{})
+	if err == nil {
+		return existingPod.Name, nil // Pod already exists
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CheckPodName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    CheckPodContainerName,
+					Image:   image,
+					Command: []string{"/bin/sh", "-c", "exit", "0"},
+				},
+			},
+		},
+	}
+
+	createdPod, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create pod: %w", err)
+	}
+
+	return createdPod.Name, nil
+}
+
+// PollPodPullStatus checks if a pod successfully pulled its image or hit an error.
+func PollPodPullStatus(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace, podName string,
+) (bool, error) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false, fmt.Errorf("timeout while checking image pull status")
+		case <-ticker.C:
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("failed to get pod: %w", err)
+			}
+
+			if len(pod.Status.ContainerStatuses) == 0 {
+				continue
+			}
+
+			state := pod.Status.ContainerStatuses[0].State
+			if state.Waiting != nil {
+				switch state.Waiting.Reason {
+				case "ErrImagePull", "ImagePullBackOff":
+					return false, fmt.Errorf("image pull failed: %s", state.Waiting.Message)
+				}
+			} else if state.Running != nil || state.Terminated != nil {
+				return true, nil
+			}
+		}
+	}
+}
+
+var createPodFunc = CreateImageCheckPod
+var pollStatusFunc = PollPodPullStatus
+
+// CanPullImage is a wrapper combining both steps.
+func CanPullImage(
+	ctx context.Context,
+	client kubernetes.Interface,
+	namespace, image string,
+) (bool, error) {
+	podName, err := createPodFunc(ctx, client, namespace, image)
+	if err != nil {
+		return false, err
+	}
+
+	// Ensure cleanup
+	defer func() {
+		_ = client.CoreV1().
+			Pods(namespace).
+			Delete(context.Background(), podName, metav1.DeleteOptions{})
+	}()
+
+	return pollStatusFunc(ctx, client, namespace, podName)
+}
+
+func GetInstallPath(cnsaVersion string) (string, error) {
+	// Install path when running tests
+	var err error
+	install_path := path.Join("../../files/", cnsaVersion, "install.yaml")
+	if _, err := os.Stat(install_path); err == nil {
+		return install_path, nil
+	}
+	// Install path when running locally
+	install_path = path.Join("files/", cnsaVersion, "install.yaml")
+	if _, err := os.Stat(install_path); err == nil {
+		return install_path, nil
+	}
+	// Install path when running in container
+	install_path = path.Join("/files/", cnsaVersion, "install.yaml")
+	if _, err := os.Stat(install_path); err == nil {
+		return install_path, nil
+	}
+
+	return "", fmt.Errorf("could not find/open install file with version %s: %w", cnsaVersion, err)
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -17,15 +17,30 @@ limitations under the License.
 package utils
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
-	configv1 "github.com/openshift/api/config/v1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	//+kubebuilder:scaffold:imports
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestDevicefinder(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Utilities Suite")
+}
 
 var _ = Describe("GetCurrentClusterVersion", func() {
 	var (
@@ -95,28 +110,361 @@ var _ = Describe("ParseAndReturnVersion", func() {
 	})
 })
 
-func TestIsOpenShiftSupported(t *testing.T) {
-	tests := []struct {
-		ibmVersion string
-		ocpVersion string
-		expected   bool
-	}{
-		{"5.1.5.0", "4.9.0", true},        // Expected to be supported
-		{"5.1.5.0", "4.12.1", false},      // Not in the supported list
-		{"5.1.7.0", "4.11.43", true},      // Supported
-		{"5.1.7.0", "4.13.34", false},     // Not supported
-		{"5.1.9.1", "4.12.7", true},       // Supported
-		{"5.1.9.1", "4.15.0", false},      // Not supported
-		{"5.2.2.0", "4.17.3", true},       // Supported
-		{"5.2.2.0", "4.18.1", false},      // Not supported
-		{"5.2.2.0", "4.15.17", true},      // Supported
-		{"invalid_version", "4.9", false}, // Invalid IBM Fusion Access version
-	}
+var _ = Describe("IsOpenShiftSupported", func() {
+	DescribeTable("IBM version + OCP version matrix",
+		func(ibmVersion string, ocpVersion string, expected bool) {
+			version, err := semver.NewVersion(ocpVersion)
+			Expect(err).ToNot(HaveOccurred())
+			result := IsOpenShiftSupported(ibmVersion, *version)
+			Expect(result).To(Equal(expected))
+		},
 
-	for _, tt := range tests {
-		result := IsOpenShiftSupported(tt.ibmVersion, *semver.MustParse(tt.ocpVersion))
-		if result != tt.expected {
-			t.Errorf("IsOpenShiftSupported(%s, %s) = %v; expected %v", tt.ibmVersion, tt.ocpVersion, result, tt.expected)
+		Entry("5.1.5.0 supports 4.9.0", "5.1.5.0", "4.9.0", true),
+		Entry("5.1.5.0 does not support 4.12.1", "5.1.5.0", "4.12.1", false),
+		Entry("5.1.7.0 supports 4.11.43", "5.1.7.0", "4.11.43", true),
+		Entry("5.1.7.0 does not support 4.13.34", "5.1.7.0", "4.13.34", false),
+		Entry("5.1.9.1 supports 4.12.7", "5.1.9.1", "4.12.7", true),
+		Entry("5.1.9.1 does not support 4.15.0", "5.1.9.1", "4.15.0", false),
+		Entry("5.2.2.0 supports 4.17.3", "5.2.2.0", "4.17.3", true),
+		Entry("5.2.2.0 does not support 4.18.1", "5.2.2.0", "4.18.1", false),
+		Entry("5.2.2.0 supports 4.15.17", "5.2.2.0", "4.15.17", true),
+	)
+
+	It("should return false for invalid IBM version", func() {
+		version, err := semver.NewVersion("4.9")
+		Expect(err).ToNot(HaveOccurred())
+		result := IsOpenShiftSupported("invalid_version", *version)
+		Expect(result).To(BeFalse())
+	})
+})
+
+var _ = Describe("Image Pull Checker", func() {
+	var (
+		client      *fake.Clientset
+		namespace   string
+		image       string
+		testTimeout time.Duration
+	)
+
+	BeforeEach(func() {
+		client = fake.NewSimpleClientset()
+		namespace = "default"
+		image = "test.registry.io/valid/image:latest"
+		testTimeout = 3 * time.Second
+	})
+
+	Describe("PollPodPullStatus", func() {
+		It("should detect ErrImagePull and return error", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-fail-pod",
+					Namespace: namespace,
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason:  "ErrImagePull",
+									Message: "image not found",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err := client.CoreV1().
+				Pods(namespace).
+				Create(context.TODO(), pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
+
+			success, err := PollPodPullStatus(ctx, client, namespace, pod.Name)
+			Expect(success).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("image pull failed"))
+		})
+
+		It("should detect success if pod is Running", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-success-pod",
+					Namespace: namespace,
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{
+									StartedAt: metav1.Now(),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err := client.CoreV1().
+				Pods(namespace).
+				Create(context.TODO(), pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
+
+			success, err := PollPodPullStatus(ctx, client, namespace, pod.Name)
+			Expect(success).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should timeout if pod never updates", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-hang-pod",
+					Namespace: namespace,
+				},
+				Status: corev1.PodStatus{}, // no ContainerStatuses
+			}
+
+			_, err := client.CoreV1().
+				Pods(namespace).
+				Create(context.TODO(), pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
+
+			success, err := PollPodPullStatus(ctx, client, namespace, pod.Name)
+			Expect(success).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timeout"))
+		})
+	})
+
+	Describe("CreateImageCheckPod", func() {
+		It("should create a pod successfully", func() {
+			ctx := context.Background()
+			podName, err := CreateImageCheckPod(ctx, client, namespace, image)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podName).To(Equal(CheckPodName))
+
+			pod, err := client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pod.Spec.Containers[0].Image).To(Equal(image))
+		})
+	})
+})
+
+var _ = Describe("CanPullImage", func() {
+	const MaxPullTimeout = 5 * time.Second
+	var (
+		client         *fake.Clientset
+		namespace      string
+		image          string
+		originalCreate func(context.Context, kubernetes.Interface, string, string) (string, error)
+		originalPoll   func(context.Context, kubernetes.Interface, string, string) (bool, error)
+	)
+
+	BeforeEach(func() {
+		client = fake.NewSimpleClientset()
+		namespace = "default"
+		image = "quay.io/example/image:latest"
+		originalCreate = CreateImageCheckPod
+		originalPoll = PollPodPullStatus
+	})
+
+	AfterEach(func() {
+
+		defer func() {
+			createPodFunc = originalCreate
+			pollStatusFunc = originalPoll
+		}()
+	})
+
+	It("returns true when pod is created and image is pullable", func() {
+		createPodFunc = func(ctx context.Context, clientset kubernetes.Interface, ns, img string) (string, error) {
+			// Simulate pod creation
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-check-pod",
+					Namespace: ns,
+				},
+			}
+			_, err := clientset.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			return pod.Name, nil
 		}
-	}
-}
+
+		pollStatusFunc = func(ctx context.Context, clientset kubernetes.Interface, ns, podName string) (bool, error) {
+			return true, nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), MaxPullTimeout)
+		defer cancel()
+
+		ok, err := CanPullImage(ctx, client, namespace, image)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		_, err = client.CoreV1().Pods(namespace).Get(ctx, "image-check-pod", metav1.GetOptions{})
+		Expect(err).To(HaveOccurred()) // Pod should have been deleted
+	})
+
+	It("returns error if image cannot be pulled", func() {
+		createPodFunc = func(ctx context.Context, clientset kubernetes.Interface, ns, img string) (string, error) {
+			return "fail-pod", nil
+		}
+		pollStatusFunc = func(ctx context.Context, clientset kubernetes.Interface, ns, podName string) (bool, error) {
+			return false, errors.New("image pull failed")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), MaxPullTimeout)
+		defer cancel()
+
+		ok, err := CanPullImage(ctx, client, namespace, image)
+		Expect(err).To(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns error if pod creation fails", func() {
+		createPodFunc = func(ctx context.Context, clientset kubernetes.Interface, ns, img string) (string, error) {
+			return "", errors.New("create failed")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), MaxPullTimeout)
+		defer cancel()
+
+		ok, err := CanPullImage(ctx, client, namespace, image)
+		Expect(err).To(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+})
+
+var _ = Describe("ParseYAMLAndExtractTestImage", func() {
+	Context("when YAML contains the correct ConfigMap with coreInit", func() {
+		It("should return the coreInit image", func() {
+			yaml := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibm-spectrum-scale-manager-config
+data:
+  controller_manager_config.yaml: |
+    images:
+      coreInit: quay.io/example/core-init@sha256:abc123
+`
+			result, err := ParseYAMLAndExtractTestImage(yaml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("quay.io/example/core-init@sha256:abc123"))
+		})
+	})
+
+	Context("when the ConfigMap exists but coreInit is missing", func() {
+		It("should return an error", func() {
+			yaml := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibm-spectrum-scale-manager-config
+data:
+  controller_manager_config.yaml: |
+    images:
+      someOtherImage: quay.io/example/other
+`
+			_, err := ParseYAMLAndExtractTestImage(yaml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("coreInit not found"))
+		})
+	})
+
+	Context("when the ConfigMap exists but controller_manager_config.yaml is missing", func() {
+		It("should return an error", func() {
+			yaml := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibm-spectrum-scale-manager-config
+data:
+  other.yaml: |
+    images:
+      coreInit: quay.io/example/core-init@sha256:abc123
+`
+			_, err := ParseYAMLAndExtractTestImage(yaml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("controller_manager_config.yaml not found"))
+		})
+	})
+
+	Context("when the embedded YAML is malformed", func() {
+		It("should return an error", func() {
+			yaml := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibm-spectrum-scale-manager-config
+data:
+  controller_manager_config.yaml: |
+    images
+      coreInit: quay.io/example/core-init@sha256:abc123
+`
+			_, err := ParseYAMLAndExtractTestImage(yaml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to parse embedded YAML"))
+		})
+	})
+
+	Context("when the ConfigMap is not present", func() {
+		It("should return an error", func() {
+			yaml := `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unrelated-config
+data:
+  controller_manager_config.yaml: |
+    images:
+      coreInit: quay.io/example/core-init@sha256:abc123
+`
+			_, err := ParseYAMLAndExtractTestImage(yaml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ConfigMap object in install yaml not found"))
+		})
+	})
+
+	Context("check all the existing manifests", func() {
+		It("should return the coreInit image", func() {
+			var matches []string
+			absPath, err := filepath.Abs("../../files")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = filepath.WalkDir(absPath, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+
+				if !d.IsDir() && d.Name() == "install.yaml" {
+					matches = append(matches, path)
+				}
+				return nil
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matches).ToNot(BeEmpty())
+
+			for _, match := range matches {
+				fmt.Printf("Checking for image in file: %s -> ", match)
+				yaml, err := os.ReadFile(match)
+				Expect(err).NotTo(HaveOccurred())
+				result, err := ParseYAMLAndExtractTestImage(string(yaml))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Not(BeEmpty()))
+				fmt.Printf("%s\n", result)
+			}
+		})
+	})
+})


### PR DESCRIPTION
- **Initial support for pulling an image and exposing that status in the CR**
- **Use new NewFusionAccessReconciler() function**
- **Improve messages when updating the pullimage status**
- **Rerun the image check if the image has failed**

## Summary by Sourcery

Add support for pulling and checking container image status in the FusionAccess custom resource

New Features:
- Implement image pull status checking mechanism for external test images
- Add new status fields to track external image pull status in FusionAccess CR

Enhancements:
- Refactor FusionAccessReconciler to include image pull checking functionality
- Improve error handling and reporting for image pull operations

Tests:
- Add comprehensive test cases for image pull status checking
- Implement test scenarios for different image pull outcomes