### PR TITLE
Fix containerfile name for operator to be operator.Dockerfile

### DIFF
--- a/.tekton/controller-rhel9-operator-0-1-on-push.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/storage-scale-releng-tenant/controller-rhel9-operator:{{revision}}
   - name: dockerfile
-    value: Dockerfile
+    value: operator.Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modified the Tekton pipeline configuration to specify 'operator.Dockerfile' as the build dockerfile