### PR TITLE
Use 'openshift,fusion,acces,san' in image labels

### DIFF
--- a/templates/bundle.Dockerfile.template
+++ b/templates/bundle.Dockerfile.template
@@ -61,5 +61,5 @@ LABEL \
     io.k8s.description="" \
     summary="" \
     io.k8s.display-name="OpenShift Fusion Access Operator" \
-    io.openshift.tags="openshift,storage,scale" \
+    io.openshift.tags="openshift,fusion,access,san" \
     License="Apache License 2.0" \

--- a/templates/console-plugin.Dockerfile.template
+++ b/templates/console-plugin.Dockerfile.template
@@ -14,7 +14,7 @@ LABEL \
     description="" \
     io.k8s.display-name="Console plugin image for OpenShift Fusion Access Operator" \
     io.k8s.description="" \
-    io.openshift.tags="openshift,storage,scale" \
+    io.openshift.tags="openshift,fusion,access,san" \
     distribution-scope="public" \
     name="openshift-fusion-access-console-plugin" \
     summary="Fusion Access Console Plugin" \

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -21,7 +21,7 @@ LABEL \
     description="" \
     io.k8s.display-name="Device Finder image for OpenShift Fusion Access Operator" \
     io.k8s.description="" \
-    io.openshift.tags="openshift,storage,scale" \
+    io.openshift.tags="openshift,fusion,access,san" \
     distribution-scope="public" \
     name="openshift-fusion-access-devicefinder" \
     summary="Device Finder" \

--- a/templates/must-gather.Dockerfile.template
+++ b/templates/must-gather.Dockerfile.template
@@ -11,7 +11,7 @@ LABEL \
     com.redhat.component="Must gather image for OpenShift Fusion Access Operator" \
     io.k8s.display-name="Must gather image for OpenShift Fusion Access Operator" \
     io.k8s.description="" \
-    io.openshift.tags="openshift,storage,scale" \
+    io.openshift.tags="openshift,fusion,access,san" \
     distribution-scope="public" \
     name="openshift-fusion-access-must-gather-rhel9" \
     vendor="Red Hat, Inc." \

--- a/templates/operator.Dockerfile.template
+++ b/templates/operator.Dockerfile.template
@@ -48,7 +48,7 @@ LABEL \
     description="" \
     io.k8s.display-name="Red Hat OpenShift Fusion Access Operator" \
     io.k8s.description="" \
-    io.openshift.tags="openshift,storage,scale" \
+    io.openshift.tags="openshift,fusion,access,san" \
     distribution-scope="public" \
     name="openshift-fusion-access-controller" \
     summary="Controller" \


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update multiple Dockerfile templates to standardize image labeling across different components