### PR TITLE
Fix wrong filename for template in CEL expression for console-plugin

### DIFF
--- a/.tekton/console-plugin-0-1-on-pull-request.yaml
+++ b/.tekton/console-plugin-0-1-on-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
       "console/***".pathChanged() ||
       ".tekton/console-plugin-0-1-on-pull-request.yaml".pathChanged() ||
-      "templates/console-plugin.Dockerfile.template.yaml".pathChanged()
+      "templates/console-plugin.Dockerfile.template".pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/console-plugin-0-1-on-push.yaml
+++ b/.tekton/console-plugin-0-1-on-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch== "main" && (
       "console/***".pathChanged() ||
       ".tekton/console-plugin-0-1-on-push.yaml".pathChanged() ||
-      "templates/console-plugin.Dockerfile.template.yaml".pathChanged()
+      "templates/console-plugin.Dockerfile.template".pathChanged()
       )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix incorrect filename extension in CEL expression for template file path in Tekton pipeline configuration