### PR TITLE
Alm example and Make fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ OPERATOR_SDK_VERSION ?= v1.39.1
 # Image URL to use all building/pushing image targets
 export OPERATOR_IMG ?= $(IMAGE_TAG_BASE)-operator:$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29.0
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -314,7 +314,7 @@ $(LOCALBIN):
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
-ENVTEST_VERSION ?= release-0.17
+ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 GOLANGCI_LINT_VERSION ?= v2.1.1
 # update for major version updates to YQ_VERSION!
 YQ_API_VERSION = v4

--- a/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
@@ -2,7 +2,19 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "fusion.storage.openshift.io/v1alpha1",
+          "kind": "FusionAccess",
+          "metadata": {
+            "name": "fusionaccess-sample"
+          },
+          "spec": {
+            "ibm_cnsa_version": "v5.2.3.0.rc1"
+          }
+        }
+      ]
     capabilities: Basic Install
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"


### PR DESCRIPTION
- **Add alm-examples for fusion access**
- **Figure out envtest version and envtest_k8s_version dynamically**

## Summary by Sourcery

Update ALM examples for Fusion Access Operator and dynamically determine envtest versions in the Makefile

New Features:
- Add sample ALM example for FusionAccess custom resource

Enhancements:
- Dynamically determine Kubernetes and controller-runtime envtest versions using Go module version information