### PR TITLE
Include check for VERSION.txt changes in CEL expression for operator, must-gather, console-plugin and devicefinder so that it triggers new builds for each component, which will trigger a nudge build for the bundle

### DIFF
--- a/.tekton/console-plugin-0-1-on-pull-request.yaml
+++ b/.tekton/console-plugin-0-1-on-pull-request.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
       "console/***".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
       ".tekton/console-plugin-0-1-on-pull-request.yaml".pathChanged() ||
       "templates/console-plugin.Dockerfile.template".pathChanged()
       )

--- a/.tekton/console-plugin-0-1-on-push.yaml
+++ b/.tekton/console-plugin-0-1-on-push.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch== "main" && (
       "console/***".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
       ".tekton/console-plugin-0-1-on-push.yaml".pathChanged() ||
       "templates/console-plugin.Dockerfile.template".pathChanged()
       )

--- a/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
       "go.mod".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
       "cmd/main.go".pathChanged() ||
       "config/***".pathChanged() ||
       "internal/common/***".pathChanged() ||

--- a/.tekton/controller-rhel9-operator-0-1-on-push.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-push.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (
       "go.mod".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
       "cmd/main.go".pathChanged() ||
       "config/***".pathChanged() ||
       "internal/common/***".pathChanged() ||

--- a/.tekton/devicefinder-0-1-on-pull-request.yaml
+++ b/.tekton/devicefinder-0-1-on-pull-request.yaml
@@ -9,8 +9,9 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
-      "cmd/devicefinder/***".pathChanged() ||
       "go.mod".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
+      "cmd/devicefinder/***".pathChanged() ||
       "internal/devicefinder/***".pathChanged()  ||
       "internal/diskutils/***".pathChanged()  ||
       "templates/devicefinder.Dockerfile.template".pathChanged() ||

--- a/.tekton/devicefinder-0-1-on-push.yaml
+++ b/.tekton/devicefinder-0-1-on-push.yaml
@@ -8,8 +8,9 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (
-      "cmd/devicefinder/***".pathChanged() ||
       "go.mod".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
+      "cmd/devicefinder/***".pathChanged() ||
       "internal/devicefinder/***".pathChanged()  ||
       "internal/diskutils/***".pathChanged()  ||
       "templates/devicefinder.Dockerfile.template".pathChanged() ||

--- a/.tekton/must-gather-0-1-on-pull-request.yaml
+++ b/.tekton/must-gather-0-1-on-pull-request.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
       "collection-scripts/***".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
       "templates/must-gather.Dockerfile.template".pathChanged() ||
       ".tekton/must-gather-0-1-on-pull-request.yaml".pathChanged() )
   creationTimestamp: null

--- a/.tekton/must-gather-0-1-on-push.yaml
+++ b/.tekton/must-gather-0-1-on-push.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (
       "collection-scripts/***".pathChanged() ||
+      "VERSION.txt".pathChanged() ||
       "templates/must-gather.Dockerfile.template".pathChanged() ||
       ".tekton/must-gather-0-1-on-push.yaml".pathChanged() )
   creationTimestamp: null


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add VERSION.txt as a trigger path for build pipelines in pull request and push workflows for devicefinder, console-plugin, operator, and must-gather components