### PR TITLE
Pullsecret Fixes

### DIFF
--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -44,7 +44,7 @@ import (
 	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/utils"
 )
 
-type CanPullImageFunc func(ctx context.Context, client kubernetes.Interface, ns, image string) (bool, error)
+type CanPullImageFunc func(ctx context.Context, client kubernetes.Interface, ns, image, pullSecret string) (bool, error)
 
 // FusionAccessReconciler reconciles a FusionAccess object
 type FusionAccessReconciler struct {
@@ -356,7 +356,7 @@ func (r *FusionAccessReconciler) Reconcile(
 			log.Log.Error(err, "Could not figure out test image", "testImage", testImage)
 			return ctrl.Result{}, err
 		}
-		ok, err := r.CanPullImage(ctx, r.fullClient, ns, testImage)
+		ok, err := r.CanPullImage(ctx, r.fullClient, ns, testImage, FUSIONPULLSECRETNAME)
 		if ok {
 			log.Log.Info("Image pull test succeeded", "ns", ns, "testImage", testImage)
 			fusionaccess.Status.ExternalImagePullStatus = fusionv1alpha1.CheckSuccess

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -360,6 +360,7 @@ func (r *FusionAccessReconciler) Reconcile(
 		if ok {
 			log.Log.Info("Image pull test succeeded", "ns", ns, "testImage", testImage)
 			fusionaccess.Status.ExternalImagePullStatus = fusionv1alpha1.CheckSuccess
+			fusionaccess.Status.ExternalImagePullError = ""
 		} else {
 			log.Log.Error(err, "Image pull test failed", "ns", ns, "testImage", testImage)
 			fusionaccess.Status.ExternalImagePullStatus = fusionv1alpha1.CheckFailed

--- a/internal/controller/fusionaccess_controller_test.go
+++ b/internal/controller/fusionaccess_controller_test.go
@@ -98,7 +98,7 @@ var _ = Describe("FusionAccess Controller", func() {
 				Client:     k8sClient,
 				Scheme:     k8sClient.Scheme(),
 				fullClient: kubeclient.NewSimpleClientset(),
-				CanPullImage: func(ctx context.Context, client kubernetes.Interface, ns, image string) (bool, error) {
+				CanPullImage: func(ctx context.Context, client kubernetes.Interface, ns, image, pullSecret string) (bool, error) {
 					return true, nil
 				},
 			}


### PR DESCRIPTION
- **Make sure we use the pull secret to do the test pull**
- **Set the pull image error text to empty to avoid confusion when pull was successful**

## Summary by Sourcery

Enhance image pull secret handling and improve error reporting for external image pulls

New Features:
- Add support for specifying pull secrets when checking image pullability

Bug Fixes:
- Ensure pull secret is used when performing image pull tests
- Prevent displaying misleading error text after successful image pull

Enhancements:
- Modify image pull checking functions to accept an optional pull secret parameter
- Clear external image pull error text when pull is successful