### PR TITLE
Update to golanglint-ci 2.1.5

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.1
+          version: v2.1.5
           args: --timeout 5m -v
 
           #--exclude SA5011

--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ $(LOCALBIN):
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
-GOLANGCI_LINT_VERSION ?= v2.1.1
+GOLANGCI_LINT_VERSION ?= v2.1.5
 # update for major version updates to YQ_VERSION!
 YQ_API_VERSION = v4
 YQ_VERSION = v4.41.1


### PR DESCRIPTION
## Summary by Sourcery

Update the golangci-lint version to v2.1.5.

Build:
- Update the default GOLANGCI_LINT_VERSION in the Makefile to v2.1.5.

CI:
- Update the golangci-lint GitHub Action to v2.1.5 in the lint workflow.