### PR TITLE
Add test for the new data, there should be 0 discovered disks

### DIFF
--- a/internal/devicefinder/discovery/discovery_test.go
+++ b/internal/devicefinder/discovery/discovery_test.go
@@ -167,5 +167,10 @@ var _ = Describe("Device Discovery", func() {
 			Expect(discoveredDisks).To(BeEmpty())
 		})
 
+		It("should have the correct number of discovered disks (san disk env)", func() {
+			discoveredDisks := getDiscoverdDevices(deviceListSanDisk.BlockDevices)
+			Expect(discoveredDisks).To(BeEmpty())
+		})
+
 	})
 })


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Added a new test to check that no disks are discovered in a SAN disk scenario