### PR TITLE
Fix preflight checks

### DIFF
--- a/scripts/fusion-access-operator-build.sh
+++ b/scripts/fusion-access-operator-build.sh
@@ -92,7 +92,8 @@ fi
 
 make VERSION=${VERSION} IMAGE_TAG_BASE=${REGISTRY}/openshift-fusion-access CHANNELS=fast USE_IMAGE_DIGESTS="" \
     manifests bundle generate docker-build docker-push bundle-build bundle-push console-build console-push \
-    devicefinder-docker-build devicefinder-docker-push catalog-build catalog-push catalog-install
+    devicefinder-docker-build devicefinder-docker-push catalog-build catalog-push catalog-install \
+    must-gather-docker-build must-gather-docker-push
 
 wait_for_resource "packagemanifest" "${OPERATOR}" "" "${CATALOGSOURCE}"
 apply_subscription

--- a/templates/console-plugin.Dockerfile.template
+++ b/templates/console-plugin.Dockerfile.template
@@ -22,9 +22,9 @@ LABEL \
     summary="Fusion Access Console Plugin" \
     release="v${VERSION}" \
     version="v${VERSION}" \
-    maintainer="Red Hat jgil@redhat.com" \
+    maintainer="michele@acksyn.org" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
-    vendor="Red Hat, Inc." \
+    vendor="IBM" \
     License="Apache License 2.0"
 
 COPY --from=builder /opt/app-root/src/licenses/ /licenses/

--- a/templates/console-plugin.Dockerfile.template
+++ b/templates/console-plugin.Dockerfile.template
@@ -7,6 +7,8 @@ COPY console/ .
 # replace version in package.json
 RUN sed -r -i "s|\"version\": \"0.0.1\"|\"version\": \"${VERSION}\"|;" ./package.json
 RUN npm ci --ignore-scripts && npm run build
+RUN mkdir licenses
+COPY LICENSE licenses/
 
 FROM registry.access.redhat.com/ubi9/nginx-120:latest
 LABEL \
@@ -25,6 +27,7 @@ LABEL \
     vendor="Red Hat, Inc." \
     License="Apache License 2.0"
 
+COPY --from=builder /opt/app-root/src/licenses/ /licenses/
 COPY --from=builder /opt/app-root/src/docker/etc/default.conf "${NGINX_CONFIGURATION_PATH}"
 COPY --from=builder /opt/app-root/src/dist .
 USER 1001

--- a/templates/console-plugin.Dockerfile.template
+++ b/templates/console-plugin.Dockerfile.template
@@ -13,7 +13,7 @@ COPY LICENSE licenses/
 FROM registry.access.redhat.com/ubi9/nginx-120:latest
 LABEL \
     com.redhat.component="Console plugin image for OpenShift Fusion Access Operator" \
-    description="" \
+    description="This is the console plugin for the OpenShift Fusion Access for SAN Operator" \
     io.k8s.display-name="Console plugin image for OpenShift Fusion Access Operator" \
     io.k8s.description="" \
     io.openshift.tags="openshift,fusion,access,san" \

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -6,6 +6,8 @@ WORKDIR /workspace
 COPY . .
 
 RUN make build-devicefinder
+RUN mkdir licenses
+COPY LICENSE licenses/
 
 FROM registry.redhat.io/ubi10/ubi:latest
 
@@ -13,6 +15,7 @@ ARG VERSION=1.0
 
 COPY --from=builder /workspace/_output/bin/devicefinder /usr/bin/
 RUN dnf install -y udev && dnf clean all
+COPY --from=builder /workspace/licenses/ /licenses/
 ENTRYPOINT ["/usr/bin/devicefinder"]
 
 LABEL \

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -20,7 +20,7 @@ ENTRYPOINT ["/usr/bin/devicefinder"]
 
 LABEL \
     com.redhat.component="Device Finder image for OpenShift Fusion Access Operator" \
-    description="" \
+    description="Device Finder image for OpenShift Fusion Access Operator" \
     io.k8s.display-name="Device Finder image for OpenShift Fusion Access Operator" \
     io.k8s.description="" \
     io.openshift.tags="openshift,fusion,access,san" \

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -29,7 +29,7 @@ LABEL \
     summary="Device Finder" \
     release="v${VERSION}" \
     version="v${VERSION}" \
-    maintainer="Red Hat jgil@redhat.com" \
+    maintainer="michele@acksyn.org" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
-    vendor="Red Hat, Inc." \
+    vendor="IBM" \
     License="Apache License 2.0"

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -11,11 +11,11 @@ COPY LICENSE licenses/
 
 FROM registry.redhat.io/ubi10/ubi:latest
 
-ARG VERSION=1.0
-
 COPY --from=builder /workspace/_output/bin/devicefinder /usr/bin/
 RUN dnf install -y udev && dnf clean all
 COPY --from=builder /workspace/licenses/ /licenses/
+ARG VERSION=1.0
+USER 65532:65532
 ENTRYPOINT ["/usr/bin/devicefinder"]
 
 LABEL \

--- a/templates/must-gather.Dockerfile.template
+++ b/templates/must-gather.Dockerfile.template
@@ -4,6 +4,8 @@ ARG VERSION=1.0
 
 # Copy our scripts
 COPY collection-scripts/* /usr/bin/
+RUN mkdir /licenses
+COPY LICENSE /licenses/
 
 USER 1001
 

--- a/templates/must-gather.Dockerfile.template
+++ b/templates/must-gather.Dockerfile.template
@@ -16,11 +16,11 @@ LABEL \
     io.openshift.tags="openshift,fusion,access,san" \
     distribution-scope="public" \
     name="openshift-fusion-access-must-gather-rhel9" \
-    vendor="Red Hat, Inc." \
+    vendor="IBM" \
     release="v${VERSION}" \
     version="v${VERSION}" \
     summary="Must gather image" \
-    description="" \
-    maintainer="Red Hat jgil@redhat.com" \
+    description="Must gather image for the OpenShift Fusion Access Operator" \
+    maintainer="michele@acksyn.org" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
     License="Apache License 2.0"

--- a/templates/operator.Dockerfile.template
+++ b/templates/operator.Dockerfile.template
@@ -44,9 +44,9 @@ ARG VERSION=1.0
 ENTRYPOINT ["/manager"]
 
 LABEL \
-    com.redhat.component="Red Hat OpenShift Fusion Access Operator" \
-    description="" \
-    io.k8s.display-name="Red Hat OpenShift Fusion Access Operator" \
+    com.redhat.component="OpenShift Fusion Access Operator" \
+    description="OpenShift Fusion Access Operator" \
+    io.k8s.display-name="OpenShift Fusion Access Operator" \
     io.k8s.description="" \
     io.openshift.tags="openshift,fusion,access,san" \
     distribution-scope="public" \
@@ -54,7 +54,7 @@ LABEL \
     summary="Controller" \
     release="v${VERSION}" \
     version="v${VERSION}" \
-    maintainer="Red Hat jgil@redhat.com" \
+    maintainer="michele@acksyn.org" \
     url="https://github.com/openshift-storage-scale/openshift-fusion-access-operator.git" \
-    vendor="Red Hat, Inc." \
+    vendor="IBM" \
     License="Apache License 2.0"


### PR DESCRIPTION
- **Add licenses to all containers**
- **Also push must-gather when building locally**
- **Test label tweak**
- **Make preflight checks pass**
- **Fix description in devicefinder**
- **Do not use root in devicefinder**

## Summary by Sourcery

Improve build and packaging processes for the fusion access operator, focusing on preflight checks and build completeness

New Features:
- Add must-gather docker build and push to the build process

Bug Fixes:
- Fix devicefinder description
- Prevent running devicefinder as root

Build:
- Update build script to include must-gather docker build and push steps

Chores:
- Ensure all containers have appropriate licensing
- Tweak test labels