### PR TITLE
Filter out non-shared disks when creating FileSystem

### DIFF
--- a/console/src/utils/fusion-access/LocalVolumeDiscoveryResult.ts
+++ b/console/src/utils/fusion-access/LocalVolumeDiscoveryResult.ts
@@ -2,5 +2,5 @@ import type { DiscoveredDevice } from "@/models/fusion-access/LocalVolumeDiscove
 
 const WWN_PREFIX_LENGTH = "uuid.".length;
 
-export const getShortWwn = (device: DiscoveredDevice, length = 8) =>
-  device.WWN.slice(WWN_PREFIX_LENGTH, WWN_PREFIX_LENGTH + length);
+export const getWwn = (device: DiscoveredDevice) =>
+  device.WWN.slice(WWN_PREFIX_LENGTH);


### PR DESCRIPTION
update name regex

## Summary by Sourcery

Filter out non-shared disks when creating filesystems, switch to full WWN identifiers, and enforce a stricter name validation regex.

Enhancements:
- Use full device WWN instead of short WWN for identifying disks
- Filter out disks not present in all storage nodes
- Update filesystem name field validation regex for stricter naming rules
- Remove unused deduplication logic for discovered devices