### PR TITLE
devicefinder udev

### DIFF
--- a/.tekton/devicefinder-0-1-on-pull-request.yaml
+++ b/.tekton/devicefinder-0-1-on-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: devicefinder.Dockerfile
+  - name: prefetch-input
+    value: [{"type": "rpm", "path": "hack/"},]
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -206,6 +208,8 @@ spec:
       params:
       - name: input
         value: $(params.prefetch-input)
+      - name: dev-package-managers
+        value: "true"
       - name: SOURCE_ARTIFACT
         value: $(tasks.generate-dockerfile.results.SCRIPT_ARTIFACT)
       - name: ociStorage

--- a/.tekton/devicefinder-0-1-on-push.yaml
+++ b/.tekton/devicefinder-0-1-on-push.yaml
@@ -32,6 +32,8 @@ spec:
     value: quay.io/redhat-user-workloads/storage-scale-releng-tenant/devicefinder-rhel9:{{revision}}
   - name: dockerfile
     value: devicefinder.Dockerfile
+  - name: prefetch-input
+    value: [{"type": "rpm", "path": "hack/"},]
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -209,6 +211,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: dev-package-managers
+        value: "true"
       runAfter:
       - generate-dockerfile
       taskRef:

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,12 @@
+RPM lockfile generation:
+
+```
+BASE_IMAGE=registry.redhat.io/ubi10-beta/ubi:latest
+podman run -it $BASE_IMAGE cat /etc/yum.repos.d/ubi.repo > ubi.repo
+sed -i 's/\[ubi-10/[ubi-10-for-$basearch/' ubi.repo
+rpm-lockfile-prototype --image $BASE_IMAGE rpms.in.yaml
+```
+Based on:  
+https://konflux.pages.redhat.com/docs/users/building/prefetching-dependencies.html#enabling-prefetch-builds-for-rpm  
+Also check this:  
+https://github.com/konflux-ci/rpm-lockfile-prototype?tab=readme-ov-file#installation

--- a/hack/rpms.in.yaml
+++ b/hack/rpms.in.yaml
@@ -1,0 +1,5 @@
+packages: [systemd-udev]
+contentOrigin:
+  repofiles:
+    - location: ./ubi.repo
+arches: [x86_64]

--- a/hack/rpms.lock.yaml
+++ b/hack/rpms.lock.yaml
@@ -1,0 +1,106 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.7.5-2.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 552188
+    checksum: sha256:0faaad16d8ff77144bd9bef889b4048491914ad75526987e6606b92f0a2f1589
+    name: cryptsetup-libs
+    evr: 2.7.5-2.el10
+    sourcerpm: cryptsetup-2.7.5-2.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/d/device-mapper-1.02.202-6.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 146542
+    checksum: sha256:e6b8993a58c3d814587df149a2f37aa28d862d8b501350b16eb93a274915f5ae
+    name: device-mapper
+    evr: 10:1.02.202-6.el10
+    sourcerpm: lvm2-2.03.28-6.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.202-6.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 187853
+    checksum: sha256:1fc2ea3d5df59daae6333408c76fd685764c17b608cfb621d173865d1488ae5e
+    name: device-mapper-libs
+    evr: 10:1.02.202-6.el10
+    sourcerpm: lvm2-2.03.28-6.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/k/kbd-2.6.4-7.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 421026
+    checksum: sha256:7dd10412d5aa4602247175ed60ff4709b470272cf0d9d51aba59b1a56cbcf1e1
+    name: kbd
+    evr: 2.6.4-7.el10
+    sourcerpm: kbd-2.6.4-7.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/k/kbd-legacy-2.6.4-7.el10.noarch.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 610872
+    checksum: sha256:da78727e75401c470d9f123df02a3a6b7e8d75fc82662d04e2eb0bb726771259
+    name: kbd-legacy
+    evr: 2.6.4-7.el10
+    sourcerpm: kbd-2.6.4-7.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/k/kbd-misc-2.6.4-7.el10.noarch.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 1778264
+    checksum: sha256:fd0633cd6c97ab3f2f41ce98aefbe8e5bd058cc97516428730d420ded2fdc48d
+    name: kbd-misc
+    evr: 2.6.4-7.el10
+    sourcerpm: kbd-2.6.4-7.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/k/kmod-31-11.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 141571
+    checksum: sha256:b2235316f1a00139e4d28807a46f60535c1efc7a8f68f10f35901ca867829475
+    name: kmod
+    evr: 31-11.el10
+    sourcerpm: kmod-31-11.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/k/kmod-libs-31-11.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 71258
+    checksum: sha256:58266f4bacbd79b8d387c71729658da1f8312f6156d6a740729d231723841df4
+    name: kmod-libs
+    evr: 31-11.el10
+    sourcerpm: kmod-31-11.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/l/libcbor-0.11.0-3.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 37307
+    checksum: sha256:fdf8446ec31ab2efddc92e0164946192bcec3b8290a3a810aa01418cdc3522c8
+    name: libcbor
+    evr: 0.11.0-3.el10
+    sourcerpm: libcbor-0.11.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/l/libfido2-1.14.0-7.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 102913
+    checksum: sha256:132ad4a76f742a97a670255869b9422e38dfa5a6885c474963242d4a0c50a088
+    name: libfido2
+    evr: 1.14.0-7.el10
+    sourcerpm: libfido2-1.14.0-7.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/s/systemd-257-9.el10_0.1.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 6001865
+    checksum: sha256:cd45bb96e6110902490146c1023ca8581f0154d16887208ee2e9bcc7bee74ea4
+    name: systemd
+    evr: 257-9.el10_0.1
+    sourcerpm: systemd-257-9.el10_0.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/s/systemd-libs-257-9.el10_0.1.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 842246
+    checksum: sha256:ad8f1ec19ac1b7f67bd90923bb579756a825e1fa05cc82c273ddba7e5614b4f8
+    name: systemd-libs
+    evr: 257-9.el10_0.1
+    sourcerpm: systemd-257-9.el10_0.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/s/systemd-pam-257-9.el10_0.1.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 309684
+    checksum: sha256:a11992b1f952b75baec3b97e873fac2bbcb7e213c0f71038c6f665bd338b15a9
+    name: systemd-pam
+    evr: 257-9.el10_0.1
+    sourcerpm: systemd-257-9.el10_0.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/s/systemd-udev-257-9.el10_0.1.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 2332687
+    checksum: sha256:810ced5d4166a50036c283b26b8d2b0f219bd20981a59283421c4ddf7a584a26
+    name: systemd-udev
+    evr: 257-9.el10_0.1
+    sourcerpm: systemd-257-9.el10_0.1.src.rpm
+  source: []
+  module_metadata: []

--- a/hack/ubi.repo
+++ b/hack/ubi.repo
@@ -1,0 +1,62 @@
+[ubi-10-for-$basearch-baseos-rpms]
+name = Red Hat Universal Base Image 10 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-baseos-debug-rpms]
+name = Red Hat Universal Base Image 10 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-baseos-source-rpms]
+name = Red Hat Universal Base Image 10 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-appstream-rpms]
+name = Red Hat Universal Base Image 10 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-appstream-debug-rpms]
+name = Red Hat Universal Base Image 10 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-appstream-source-rpms]
+name = Red Hat Universal Base Image 10 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-codeready-builder-rpms]
+name = Red Hat Universal Base Image 10 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-codeready-builder-debug-rpms]
+name = Red Hat Universal Base Image 10 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-10-for-$basearch-codeready-builder-source-rpms]
+name = Red Hat Universal Base Image 10 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1

--- a/internal/devicefinder/discovery/monitor.go
+++ b/internal/devicefinder/discovery/monitor.go
@@ -56,8 +56,7 @@ func udevBlockMonitor(c chan string, period time.Duration) {
 func rawUdevBlockMonitor(c chan string, matches, exclusions []string) {
 	defer close(c)
 
-	// stdbuf -oL performs line bufferred output
-	cmd := exec.Command("stdbuf", "-oL", "udevadm", "monitor", "-u", "-k", "-s", "block")
+	cmd := exec.Command("udevadm", "monitor", "-u", "-k", "-s", "block")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		klog.Warningf("Cannot open udevadm stdout: %v", err)

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -13,7 +13,7 @@ FROM registry.redhat.io/ubi10-beta/ubi:latest
 ARG VERSION=1.0
 
 COPY --from=builder /workspace/_output/bin/devicefinder /usr/bin/
-
+RUN dnf install -y udev && dnf clean all
 ENTRYPOINT ["/usr/bin/devicefinder"]
 
 LABEL \


### PR DESCRIPTION
- **Update registry.redhat.io/openshift4/ose-tools-rhel8 Docker digest to bf373b4**
- **[Konflux nudge]: Update console-plugin-0-1 to 7ccf173**
- **Fix udev triggers in devicefinder**

## Summary by Sourcery

Update OpenShift image digests and fix udevadm monitoring in devicefinder

Bug Fixes:
- Remove stdbuf wrapper around udevadm monitor to restore raw udev event streaming

Build:
- Update registry.redhat.io/openshift4/ose-tools-rhel8 Docker digest to bf373b4
- Bump console-plugin-0-1 image to digest 7ccf173