### PR TITLE
external manifest

### DIFF
--- a/api/v1alpha1/fusionaccess_types.go
+++ b/api/v1alpha1/fusionaccess_types.go
@@ -44,6 +44,9 @@ type FusionAccessSpec struct {
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	LocalVolumeDiscovery StorageDeviceDiscovery `json:"storagedevicediscovery,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	// +kubebuilder:validation:Format=uri
+	ExternalManifestURL string `json:"externalManifestURL,omitempty"`
 }
 type StorageDeviceDiscovery struct {
 	// +kubebuilder:default:=true

--- a/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
+++ b/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
@@ -39,6 +39,9 @@ spec:
           spec:
             description: FusionAccessSpec defines the desired state of FusionAccess
             properties:
+              externalManifestURL:
+                format: uri
+                type: string
               ibm_cnsa_version:
                 description: Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
                 enum:

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -309,10 +309,16 @@ func (r *FusionAccessReconciler) Reconcile(
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	// Load and install manifests from ibm
+	// Load and install manifests from ibm (from the repo)
 	install_path, err := utils.GetInstallPath(string(fusionaccess.Spec.IbmCnsaVersion))
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Load and install manifests from external url if defined
+	if fusionaccess.Spec.ExternalManifestURL != "" {
+		// TODO add additional validation for external manifest/url before applying it blindly
+		install_path = fusionaccess.Spec.ExternalManifestURL
 	}
 
 	installManifest, err := manifestival.NewManifest(


### PR DESCRIPTION
- **Update registry.redhat.io/openshift4/ose-tools-rhel8 Docker digest to bf373b4**
- **[Konflux nudge]: Update console-plugin-0-1 to 7ccf173**
- **Add option to CR to load external manifests from urls**

## Summary by Sourcery

Enable loading installation manifests from an external URL by adding a new field to the FusionAccess CRD and updating the reconciler to use it when provided.

New Features:
- Add ExternalManifestURL field to FusionAccessSpec and update CRD schema to allow specifying an external manifest URL.

Enhancements:
- Modify the reconcile logic to load manifests from the ExternalManifestURL when set, overriding the default install path.