### PR TITLE
Change operator namespace to ibm-prefixed

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -8,6 +8,6 @@ version >> /must-gather/version # imageVersion  - Build version
 imageId >> /must-gather/version # imageID  -  repository@digest          
 
 # Run the Collection of Resources using inspect
-oc adm inspect --dest-dir must-gather --rotated-pod-logs --all-namespaces "ns/openshift-fusion-access"
+oc adm inspect --dest-dir must-gather --rotated-pod-logs --all-namespaces "ns/ibm-fusion-access"
 
 exit 0

--- a/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/initialization-resource: '{"apiVersion":"fusion.storage.openshift.io/v1alpha1","kind":"FusionAccess","metadata":{"name":"fusionaccess-object"},"spec":{"ibm_cnsa_version":"v5.2.3.0"}}'
-    operatorframework.io/suggested-namespace: openshift-fusion-access
+    operatorframework.io/suggested-namespace: ibm-fusion-access
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.openshift.io/valid-subscription: '["Openshift Container Platform","OpenShift
       Virtualization Engine"]'

--- a/console/src/hooks/useWatchFusionAccess.ts
+++ b/console/src/hooks/useWatchFusionAccess.ts
@@ -12,7 +12,7 @@ export const useWatchFusionAccess: UseK8sWatchResourceWithInferedList<
   return useK8sWatchResource({
     ...options,
     namespaced: true,
-    namespace: "openshift-fusion-access",
+    namespace: "ibm-fusion-access",
     groupVersionKind: {
       group: "fusion.storage.openshift.io",
       version: "v1alpha1",

--- a/scripts/fusion-access-operator-build.sh
+++ b/scripts/fusion-access-operator-build.sh
@@ -2,7 +2,7 @@
 set -x -e -o pipefail
 
 CATALOGSOURCE="test-openshift-fusion-access-operator"
-NS="openshift-fusion-access"
+NS="ibm-fusion-access"
 OPERATOR="openshift-fusion-access-operator"
 VERSION="${VERSION:-6.6.6}"
 REGISTRY="${REGISTRY:-kuemper.int.rhx/bandini}"


### PR DESCRIPTION
## Summary by Sourcery

Update operator namespace prefix across all references from 'openshift-fusion-access' to 'ibm-fusion-access'.

Enhancements:
- Rename operatorframework.io/suggested-namespace annotation in the CSV manifest to ibm-fusion-access.
- Update console watch hook to use the ibm-fusion-access namespace.
- Adjust build script NS variable to ibm-fusion-access.