### PR TITLE
Make sure we drop the bundle folder and call clean when releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: clean
 clean: ## Remove build artifacts and downloaded tools
+	rm -rf ./bundle
 	find bin/ -exec chmod +w "{}" \;
 	rm -rf ./manager ./bin/* ./cover.out ./coverage.html
 	rm -f ./config/samples/fusionaccess-catalog-*.yaml

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 
 VERSION=$(cat VERSION.txt)
 
-make USE_IMAGE_DIGESTS="" bundle generate manifests docker-build docker-push \
+make USE_IMAGE_DIGESTS="" clean bundle generate manifests docker-build docker-push \
     bundle-build bundle-push \
     console-build console-push devicefinder-docker-build devicefinder-docker-push \
     must-gather-docker-build must-gather-docker-push


### PR DESCRIPTION
This prevents shipping old spurious files when renaming things
