### PR TITLE
Switch to ubi10 proper

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,7 +1,7 @@
 RPM lockfile generation:
 
 ```
-BASE_IMAGE=registry.redhat.io/ubi10-beta/ubi:latest
+BASE_IMAGE=registry.redhat.io/ubi10/ubi:latest
 podman run -it $BASE_IMAGE cat /etc/yum.repos.d/ubi.repo > ubi.repo
 sed -i 's/\[ubi-10/[ubi-10-for-$basearch/' ubi.repo
 rpm-lockfile-prototype --image $BASE_IMAGE rpms.in.yaml

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -7,8 +7,7 @@ COPY . .
 
 RUN make build-devicefinder
 
-# Change this once ubi10 moves out of beta
-FROM registry.redhat.io/ubi10-beta/ubi:latest
+FROM registry.redhat.io/ubi10/ubi:latest
 
 ARG VERSION=1.0
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Switch the base UBI 10 image reference from the beta registry to the stable registry