### PR TITLE
Fix typo in fusionaccess cr displayname

### DIFF
--- a/api/v1alpha1/fusionaccess_types.go
+++ b/api/v1alpha1/fusionaccess_types.go
@@ -39,7 +39,7 @@ type FusionAccessSpec struct {
 	// ./scripts/update-cnsa-versions-metadata.sh
 
 	// Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.rc1","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.1"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="IBM CNSA Version",order=2,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.rc1","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.1"}
 	IbmCnsaVersion CNSAVersions `json:"ibm_cnsa_version,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}

--- a/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ spec:
       name: fusionaccesses.fusion.storage.openshift.io
       specDescriptors:
       - description: Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
-        displayName: Ibm Cnsa Version
+        displayName: IBM CNSA Version
         path: ibm_cnsa_version
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0


### PR DESCRIPTION
Fixes: OCPNAS-121

## Summary by Sourcery

Correct typos in FusionAccess CRD displayName for IBM CNSA version and update hack README base image reference.

Bug Fixes:
- Fix displayName typo for IBM CNSA Version in FusionAccess CRD annotation and CSV manifest

Documentation:
- Update hack/README.md to use correct BASE_IMAGE registry.redhat.io/ubi10/ubi:latest