### PR TITLE
Skip pullimage check when using external manifests

### DIFF
--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -361,9 +361,14 @@ func (r *FusionAccessReconciler) Reconcile(
 	}
 
 	// Check if can pull the image if we have not already or if it failed previously
-	err = r.runPullImageCheck(ctx, ns, fusionaccess)
-	if err != nil {
-		return ctrl.Result{}, err
+	// Only do this check if we have a set cnsa version
+	if fusionaccess.Spec.IbmCnsaVersion != "" {
+		err = r.runPullImageCheck(ctx, ns, fusionaccess)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		log.Log.Info("Skipping image pull check as we are not using a CNSA version in the spec")
 	}
 
 	if err := console.CreateOrUpdatePlugin(ctx, r.Client); err != nil {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Skip the image pull availability check when no IBM CNSA version is specified, allowing external manifest usage