### PR TITLE
fix gpfs ui link

### DIFF
--- a/console/src/components/GpfsDashboardLink.tsx
+++ b/console/src/components/GpfsDashboardLink.tsx
@@ -48,7 +48,7 @@ const GpfsDashboardLink: React.FC<GpfsDashboardLinkProps> = ({
       iconPosition="end"
       isInline
     >
-      {href}
+      {fileSystem.metadata?.name || ""}
     </Button>
   );
 };


### PR DESCRIPTION
- **Update Konflux references**
- **Switch to ubi10 proper**
- **[Konflux nudge]: Update controller-rhel9-operator-0-1 to 288b9e8**
- **[Konflux nudge]: Update must-gather-0-1 to 22f25ee**
- **[Konflux nudge]: Update devicefinder-0-1 to c01eabf**
- **[Konflux nudge]: Update console-plugin-0-1 to 4befa47**
- **Fix typo in fusionaccess cr displayname**
- **[Konflux nudge]: Update controller-rhel9-operator-0-1 to b165b53**
- **Make sure the externalmanifesturl has precedence**
- **Release 0.0.16**
- **[Konflux nudge]: Update controller-rhel9-operator-0-1 to d8a715c**
- **[Konflux nudge]: Update devicefinder-0-1 to d45fef0**
- **Skip pullimage check when using external manifests**
- **[Konflux nudge]: Update controller-rhel9-operator-0-1 to 72f8762**
- **fix(console): Only show the fsname for the IBM gui link**
