### PR TITLE
lockdown ext manifest

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -349,3 +349,10 @@ func GetInstallPath(cnsaVersion string) (string, error) {
 
 	return "", fmt.Errorf("could not find/open install file with version %s: %w", cnsaVersion, err)
 }
+
+func IsExternalManifestURLAllowed(url string) bool {
+	const allowedPrefix = "https://raw.githubusercontent.com/openshift-storage-scale"
+	url = strings.TrimSpace(url)
+	url = strings.ToLower(url)
+	return strings.HasPrefix(url, allowedPrefix)
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -463,3 +463,45 @@ data:
 		})
 	})
 })
+
+var _ = Describe("HasPrefix", func() {
+	It("should match exact prefix", func() {
+		url := "https://raw.githubusercontent.com/openshift-storage-scale"
+		Expect(IsExternalManifestURLAllowed(url)).To(BeTrue())
+	})
+
+	It("should match with a path after the prefix", func() {
+		url := "https://raw.githubusercontent.com/openshift-storage-scale/project1"
+		Expect(IsExternalManifestURLAllowed(url)).To(BeTrue())
+	})
+
+	It("should match with leading/trailing whitespace", func() {
+		url := "   https://raw.githubusercontent.com/openshift-storage-scale/project1   "
+		Expect(IsExternalManifestURLAllowed(url)).To(BeTrue())
+	})
+
+	It("should match with uppercase URL", func() {
+		url := "HTTPS://RAW.GITHUBUSERCONTENT.COM/OPENSHIFT-STORAGE-SCALE/PROJECT1"
+		Expect(IsExternalManifestURLAllowed(url)).To(BeTrue())
+	})
+
+	It("should not match similar but incorrect prefix", func() {
+		url := "https://raw.githubusercontent.com/openshift/project1"
+		Expect(IsExternalManifestURLAllowed(url)).To(BeFalse())
+	})
+
+	It("should not match similar but incorrect host", func() {
+		url := "https://github.com/openshift-storage-scale/project1"
+		Expect(IsExternalManifestURLAllowed(url)).To(BeFalse())
+	})
+
+	It("should not match if protocol is different", func() {
+		url := "http://raw.githubusercontent.com/openshift-storage-scale"
+		Expect(IsExternalManifestURLAllowed(url)).To(BeFalse())
+	})
+
+	It("should not match random strings", func() {
+		url := "some-random-string"
+		Expect(IsExternalManifestURLAllowed(url)).To(BeFalse())
+	})
+})

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -464,7 +464,7 @@ data:
 	})
 })
 
-var _ = Describe("HasPrefix", func() {
+var _ = Describe("IsExternalManifestURLAllowed", func() {
 	It("should match exact prefix", func() {
 		url := "https://raw.githubusercontent.com/openshift-storage-scale"
 		Expect(IsExternalManifestURLAllowed(url)).To(BeTrue())


### PR DESCRIPTION
- **Add a function to check the prefix for the externalManifestURL**
- **Move externalmanifest and cnsa checking logic into a separate function**

## Summary by Sourcery

Unify and secure manifest retrieval by extracting selection and validation logic into a dedicated helper and enforcing a strict URL prefix policy

Enhancements:
- Consolidate external vs IBM repo manifest selection logic into a getIbmManifest helper
- Introduce IsExternalManifestURLAllowed utility to enforce allowed URL prefix for external manifests

Tests:
- Add unit tests for getIbmManifest covering valid and invalid external URLs, CNSA version selection, and missing inputs
- Add unit tests for IsExternalManifestURLAllowed covering various URL formats and edge cases