### PR TITLE
Add check if multipath member has no children

### DIFF
--- a/internal/diskutils/diskutil.go
+++ b/internal/diskutils/diskutil.go
@@ -81,8 +81,11 @@ func (b *BlockDevice) BiosPartition() bool {
 // GetDevPath for block device (/dev/sdx)
 func (b *BlockDevice) GetDevPath() (path string, err error) {
 	if b.FSType == "mpath_member" {
-		// mpaths always have a single children
-		return fmt.Sprintf("/dev/%s", b.Children[0].KName), nil
+		// correct mpaths always have a single children
+		if len(b.Children) != 0 {
+			return fmt.Sprintf("/dev/%s", b.Children[0].KName), nil
+		}
+		return "", fmt.Errorf("no multipath members found %s", b.KName)
 	}
 	return b.Path, nil
 }
@@ -90,7 +93,11 @@ func (b *BlockDevice) GetDevPath() (path string, err error) {
 // GetPathByID check on BlockDevice
 func (b *BlockDevice) GetPathByID() (string, error) {
 	if b.FSType == "mpath_member" {
-		return fmt.Sprintf("/dev/disk/by-id/%s", b.Children[0].PathByID), nil
+		// correct mpaths always have a single children
+		if len(b.Children) != 0 {
+			return fmt.Sprintf("/dev/disk/by-id/%s", b.Children[0].PathByID), nil
+		}
+		return "", fmt.Errorf("no multipath members found %s", b.KName)
 	}
 
 	if b.PathByID != "" {

--- a/internal/diskutils/diskutil_test.go
+++ b/internal/diskutils/diskutil_test.go
@@ -59,16 +59,17 @@ var _ = Describe("BlockDevice", func() {
 			Expect(path).To(Equal("/dev/dm-0"))
 		})
 
-		// Need to fix the code first
-		// It("errors out when mpath_member has no children", func() {
-		// 	device := &BlockDevice{
-		// 		FSType:   "mpath_member",
-		// 		Children: []BlockDevice{},
-		// 	}
-		// 	path, err := device.GetDevPath()
-		// 	Expect(err).ToNot(HaveOccurred())
-		// 	Expect(path).To(Equal("/dev/dm-0"))
-		// })
+		It("errors out when mpath_member has no children", func() {
+			device := &BlockDevice{
+				FSType:   "mpath_member",
+				Path:     "/dev/sdd",
+				Children: []BlockDevice{},
+			}
+			path, err := device.GetDevPath()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no multipath members found"))
+			Expect(path).To(Equal(""))
+		})
 
 		It("returns Path otherwise", func() {
 			device := &BlockDevice{
@@ -101,6 +102,17 @@ var _ = Describe("BlockDevice", func() {
 			path, err := device.GetPathByID()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(path).To(Equal("/dev/disk/by-id/wwn-456"))
+		})
+
+		It("errors out when mpath_member has no children", func() {
+			device := &BlockDevice{
+				FSType:   "mpath_member",
+				Path:     "/dev/sdd",
+				Children: []BlockDevice{},
+			}
+			_, err := device.GetPathByID()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no multipath members found"))
 		})
 
 		It("returns error if no PathByID", func() {


### PR DESCRIPTION
This can happen eg. if someone flushes the multipath device maps.

Resolves: #436
