### PR TITLE
Make sure we do not release without pull.txt for now

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,6 +3,11 @@ set -e -o pipefail
 
 VERSION=$(cat VERSION.txt)
 
+if [ ! -s "internal/controller/pull.txt" ]; then
+  echo "Error: pull.txt is empty." >&2
+  exit 1
+fi
+
 make USE_IMAGE_DIGESTS="" clean bundle generate manifests docker-build docker-push \
     bundle-build bundle-push \
     console-build console-push devicefinder-docker-build devicefinder-docker-push \


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add a pre-release check in the release script to abort if internal/controller/pull.txt is missing or empty