### PR TITLE
Drop old unused names in the spec and add some consistency

### DIFF
--- a/api/v1alpha1/fusionaccess_types.go
+++ b/api/v1alpha1/fusionaccess_types.go
@@ -23,7 +23,7 @@ import (
 // NOTE(bandini): If you change anything in the following two lines you need to update
 // ./scripts/update-cnsa-versions-metadata.sh
 // +kubebuilder:validation:Enum=v5.2.3.0;v5.2.3.0.rc1;v5.2.3.0.1
-type CNSAVersions string
+type StorageScaleVersions string
 
 // FusionAccessSpec defines the desired state of FusionAccess
 type FusionAccessSpec struct {
@@ -31,11 +31,11 @@ type FusionAccessSpec struct {
 	// ./scripts/update-cnsa-versions-metadata.sh
 
 	// Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="IBM CNSA Version",order=2,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.rc1","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.1"}
-	IbmCnsaVersion CNSAVersions `json:"ibm_cnsa_version,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="IBM Storage Scale Version",order=2,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.rc1","urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.1"}
+	StorageScaleVersion StorageScaleVersions `json:"storageScaleVersion,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
-	LocalVolumeDiscovery StorageDeviceDiscovery `json:"storagedevicediscovery,omitempty"`
+	LocalVolumeDiscovery StorageDeviceDiscovery `json:"storageDeviceDiscovery,omitempty"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +kubebuilder:validation:Format=uri
 	ExternalManifestURL string `json:"externalManifestURL,omitempty"`

--- a/api/v1alpha1/fusionaccess_webhook.go
+++ b/api/v1alpha1/fusionaccess_webhook.go
@@ -96,12 +96,12 @@ func (r *FusionAccessValidator) ValidateCreate(ctx context.Context, obj runtime.
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current cluster version: %v", err)
 	}
-	if !utils.IsOpenShiftSupported(string(p.Spec.IbmCnsaVersion), *ocpVersion) {
+	if !utils.IsOpenShiftSupported(string(p.Spec.StorageScaleVersion), *ocpVersion) {
 		// FIXME(bandini): we currently only log this so QE can test on upcoming versions that are not yet supported by IBM
-		fusionaccesslog.Info("IBM CNSA version not supported", "OCP Version", ocpVersion, "IBM CNSA Version", p.Spec.IbmCnsaVersion)
-		// FIXME(bandini): return nil, fmt.Errorf("IBM CNSA version %s is not supported", ocpVersion)
+		fusionaccesslog.Info("IBM Storage Scale version not supported", "OCP Version", ocpVersion, "IBM Storage ScaleVersion", p.Spec.StorageScaleVersion)
+		// FIXME(bandini): return nil, fmt.Errorf("IBM Storage Scale version %s is not supported", ocpVersion)
 	} else {
-		fusionaccesslog.Info("validate create", "name", p.Name, "OCP Version", ocpVersion, "IBM CNSA Version", p.Spec.IbmCnsaVersion)
+		fusionaccesslog.Info("validate create", "name", p.Name, "OCP Version", ocpVersion, "IBM Storage Scale Version", p.Spec.StorageScaleVersion)
 	}
 	return nil, nil
 }
@@ -130,9 +130,9 @@ func (r *FusionAccessValidator) ValidateUpdate(_ context.Context, oldObj, newObj
 		"name",
 		p.Name,
 		"new version",
-		pNew.Spec.IbmCnsaVersion,
+		pNew.Spec.StorageScaleVersion,
 		"old version",
-		p.Spec.IbmCnsaVersion,
+		p.Spec.StorageScaleVersion,
 	)
 
 	return nil, nil

--- a/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
+++ b/config/crd/bases/fusion.storage.openshift.io_fusionaccesses.yaml
@@ -42,19 +42,19 @@ spec:
               externalManifestURL:
                 format: uri
                 type: string
-              ibm_cnsa_version:
+              storageDeviceDiscovery:
+                properties:
+                  create:
+                    default: true
+                    type: boolean
+                type: object
+              storageScaleVersion:
                 description: Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
                 enum:
                 - v5.2.3.0
                 - v5.2.3.0.rc1
                 - v5.2.3.0.1
                 type: string
-              storagedevicediscovery:
-                properties:
-                  create:
-                    default: true
-                    type: boolean
-                type: object
             type: object
           status:
             description: FusionAccessStatus defines the observed state of FusionAccess

--- a/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operatorframework.io/initialization-resource: '{"apiVersion":"fusion.storage.openshift.io/v1alpha1","kind":"FusionAccess","metadata":{"name":"fusionaccess-object"},"spec":{"ibm_cnsa_version":"v5.2.3.0.1"}}'
+    operatorframework.io/initialization-resource: '{"apiVersion":"fusion.storage.openshift.io/v1alpha1","kind":"FusionAccess","metadata":{"name":"fusionaccess-object"},"spec":{"storageScaleVersion":"v5.2.3.0.1"}}'
     operatorframework.io/suggested-namespace: ibm-fusion-access
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.openshift.io/valid-subscription: '["Openshift Container Platform","OpenShift
@@ -44,14 +44,14 @@ spec:
       name: fusionaccesses.fusion.storage.openshift.io
       specDescriptors:
       - description: Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
-        displayName: IBM CNSA Version
-        path: ibm_cnsa_version
+        displayName: IBM Storage Scale Version
+        path: storageScaleVersion
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0
         - urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.rc1
         - urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.0.1
       - displayName: Local Volume Discovery
-        path: storagedevicediscovery
+        path: storageDeviceDiscovery
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: External Manifest URL

--- a/config/samples/fusion_v1alpha1_fusionaccess.yaml
+++ b/config/samples/fusion_v1alpha1_fusionaccess.yaml
@@ -3,4 +3,4 @@ kind: FusionAccess
 metadata:
   name: fusionaccess-object
 spec:
-  ibm_cnsa_version: "v5.2.3.0.1"
+  storageScaleVersion: "v5.2.3.0.1"

--- a/console/src/models/fusion-access/FusionAccess.ts
+++ b/console/src/models/fusion-access/FusionAccess.ts
@@ -2,8 +2,8 @@ import type { K8sResourceKind } from "@openshift-console/dynamic-plugin-sdk";
 
 export interface FusionAccess extends K8sResourceKind {
   spec?: {
-    ibm_cnsa_version?: "v5.2.3.0";
-    storagedevicediscovery?: {
+    storageScaleVersion?: "v5.2.3.0";
+    storageDeviceDiscovery?: {
       create?: boolean;
     };
   };

--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -366,7 +366,7 @@ func (r *FusionAccessReconciler) Reconcile(
 
 	// Check if can pull the image if we have not already or if it failed previously
 	// Only do this check if we have a set cnsa version
-	if fusionaccess.Spec.IbmCnsaVersion != "" {
+	if fusionaccess.Spec.StorageScaleVersion != "" {
 		err = r.runPullImageCheck(ctx, ns, fusionaccess)
 		if err != nil {
 			fusionaccess.Status.Status = "ErrImagePull"
@@ -465,7 +465,7 @@ func (r *FusionAccessReconciler) getPullSecretSelector(
 }
 
 func (r *FusionAccessReconciler) runPullImageCheck(ctx context.Context, ns string, fusionaccess *fusionv1alpha1.FusionAccess) error {
-	testImage, err := utils.GetExternalTestImage(string(fusionaccess.Spec.IbmCnsaVersion))
+	testImage, err := utils.GetExternalTestImage(string(fusionaccess.Spec.StorageScaleVersion))
 	if err != nil {
 		log.Log.Error(err, "Could not figure out test image", "testImage", testImage)
 		return err
@@ -481,7 +481,7 @@ func (r *FusionAccessReconciler) runPullImageCheck(ctx context.Context, ns strin
 
 func getIbmManifest(fusionobj fusionv1alpha1.FusionAccessSpec) (string, error) {
 	extManifestURL := fusionobj.ExternalManifestURL
-	ibmCnsaVersion := fusionobj.IbmCnsaVersion
+	ibmCnsaVersion := fusionobj.StorageScaleVersion
 	if extManifestURL != "" {
 		log.Log.Info(fmt.Sprintf("Using external manifest URL: %s", extManifestURL))
 		if utils.IsExternalManifestURLAllowed(extManifestURL) {

--- a/internal/controller/fusionaccess_controller_test.go
+++ b/internal/controller/fusionaccess_controller_test.go
@@ -84,7 +84,7 @@ var _ = Describe("FusionAccess Controller", func() {
 					Namespace: "default",
 				},
 				Spec: fusionv1alpha.FusionAccessSpec{
-					IbmCnsaVersion:       "v5.2.3.0",
+					StorageScaleVersion:  "v5.2.3.0",
 					LocalVolumeDiscovery: fusionv1alpha.StorageDeviceDiscovery{
 						// Create: false,
 					},
@@ -227,7 +227,7 @@ var _ = Describe("getIbmManifest", func() {
 		It("should return the external URL if allowed", func() {
 			fusionObj := fusionv1alpha.FusionAccessSpec{
 				ExternalManifestURL: "https://raw.githubusercontent.com/openshift-storage-scale/openshift-fusion-access-manifests/refs/heads/main/manifests/5.2.3.1.dev2/install.yaml",
-				IbmCnsaVersion:      "",
+				StorageScaleVersion: "",
 			}
 
 			url, err := getIbmManifest(fusionObj)
@@ -238,7 +238,7 @@ var _ = Describe("getIbmManifest", func() {
 		It("should return an error if external URL is disallowed", func() {
 			fusionObj := fusionv1alpha.FusionAccessSpec{
 				ExternalManifestURL: "http://bad-url.com",
-				IbmCnsaVersion:      "",
+				StorageScaleVersion: "",
 			}
 
 			_, err := getIbmManifest(fusionObj)
@@ -251,7 +251,7 @@ var _ = Describe("getIbmManifest", func() {
 		It("should return the install path", func() {
 			fusionObj := fusionv1alpha.FusionAccessSpec{
 				ExternalManifestURL: "",
-				IbmCnsaVersion:      "v5.2.3.0.1",
+				StorageScaleVersion: "v5.2.3.0.1",
 			}
 
 			path, err := getIbmManifest(fusionObj)
@@ -260,7 +260,7 @@ var _ = Describe("getIbmManifest", func() {
 		})
 	})
 
-	Context("when neither ExternalManifestURL nor IbmCnsaVersion is set", func() {
+	Context("when neither ExternalManifestURL nor StorageScaleVersion is set", func() {
 		It("should return an error", func() {
 			fusionObj := fusionv1alpha.FusionAccessSpec{}
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Rename spec.IbmCnsaVersion to spec.StorageScaleVersion and storagedevicediscovery to storageDeviceDiscovery across CRD schema, API types, controllers, webhooks, tests, console models, samples, and CSV descriptors