### PR TITLE
Ship lxtrace like it were firmware

### DIFF
--- a/files/v5.2.3.1.dev3/install.yaml
+++ b/files/v5.2.3.1.dev3/install.yaml
@@ -10706,7 +10706,7 @@ data:
   buildgpl: |-
     #!/bin/sh
     kerv=$(uname -r)
-    touch /usr/lpp/mmfs/bin/lxtrace-$kerv
+    rsync -av /host/var/lib/firmware/lxtrace-* /usr/lpp/mmfs/bin/
     if ! lsmod | grep -q "^mmfslinux"; then
       echo "Error: Kernel module is not loaded yet"
       exit 1

--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -163,6 +163,9 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 							"mmfslinux",
 							"tracedev",
 						},
+						// This is used to copy the lxtrace binary from /opt/lxtrace/${KERNEL_FULL_VERSION}/*
+						// to kmm-operator-manager-config` at `worker.setFirmwareClassPath`
+						FirmwarePath: "/opt/lxtrace/",
 					},
 					RegistryTLS: kmmv1beta1.TLSOptions{
 						Insecure:              kmmImageConfig.TLSInsecure,
@@ -322,9 +325,10 @@ RUN cp -avf /lib/modules/${KERNEL_FULL_VERSION}/extra/*.ko /opt/lib/modules/${KE
 RUN depmod -b /opt
 FROM registry.redhat.io/ubi9/ubi-minimal
 ARG KERNEL_FULL_VERSION
-RUN mkdir -p /opt/lib/modules/${KERNEL_FULL_VERSION}/
+RUN mkdir -p /opt/lib/modules/${KERNEL_FULL_VERSION}/ /opt/lxtrace/
 COPY --from=builder /opt/lib/modules/${KERNEL_FULL_VERSION}/*.ko /opt/lib/modules/${KERNEL_FULL_VERSION}/
-COPY --from=builder /opt/lib/modules/${KERNEL_FULL_VERSION}/modules* /opt/lib/modules/${KERNEL_FULL_VERSION}/`
+COPY --from=builder /opt/lib/modules/${KERNEL_FULL_VERSION}/modules* /opt/lib/modules/${KERNEL_FULL_VERSION}/
+COPY --from=builder /usr/lpp/mmfs/bin/lxtrace-${KERNEL_FULL_VERSION} /opt/lxtrace/`
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The spectrum kernel module build also produces a userspace tool that is
tightly coupled with the kernel version. It is called lxtrace-$(uname -r)
and it is needed whenever we need to debug gpfs at lower levels.
`mmtracectl --start` is the command to check this.

So we copy this lxtrace-$(uname-r) binary in /opt/lxtrace during the KMM
build, the KMM operator will place it under /var/lib/firmware on the
nodes and then in the buildgpl configmap we take it from
/var/lib/firmware/ and copy it from /host/var/lib/firmware/lxtrace-*
to /usr/lpp/mmfs/bin/
