### PR TITLE
Always pull kmm image

### DIFF
--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -156,6 +156,7 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 		Spec: kmmv1beta1.ModuleSpec{
 			ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
 				Container: kmmv1beta1.ModuleLoaderContainerSpec{
+					ImagePullPolicy: corev1.PullAlways,
 					Modprobe: kmmv1beta1.ModprobeSpec{
 						ModuleName: "mmfs26",
 						ModulesLoadingOrder: []string{


### PR DESCRIPTION
Use case here is if a user deploys fusion without secret signing and
then later wants to retrigger a build with the secret for signing
modules in place. Without this, you have to disable the kmm pods, go on
every node and remove the existing kmm build image via crictl commands.

## Summary by Sourcery

Enhancements:
- Always pull the KMM image by setting ImagePullPolicy to PullAlways in the module loader container spec.