### PR TITLE
Add openshift version annotation to bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL) $(USE_IMAGE_DIGESTS)
 
-BUNDLE_CONTAINERFILE_TEMPLATE ?= new-bundle.Dockerfile
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #
@@ -363,6 +362,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	$(KUSTOMIZE) build config/manifests | envsubst | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	# Since https://www.github.com/operator-framework/operator-sdk/issues/6598 we copy the dependencies file on our own
 	cp -f ./config/olm-dependencies.yaml ./bundle/metadata/dependencies.yaml
+	./hack/add_openshift_version_annotation.sh
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/hack/add_openshift_version_annotation.sh
+++ b/hack/add_openshift_version_annotation.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+OPENSHIFT_VERSIONS="\"v4.19\""
+
+{
+  echo ""
+  echo "  # OpenShift minimum version"
+  echo "  com.redhat.openshift.versions: $OPENSHIFT_VERSIONS"
+} >> bundle/metadata/annotations.yaml
+
+echo "LABEL com.redhat.openshift.versions=$OPENSHIFT_VERSIONS" >> bundle.Dockerfile


### PR DESCRIPTION
## Summary by Sourcery

Add OpenShift version annotation to the operator bundle and its container image

Enhancements:
- Append `com.redhat.openshift.versions` annotation to bundle metadata and corresponding LABEL to bundle Dockerfile via a new script
- Invoke the annotation script in the Makefile’s `bundle` target

Chores:
- Remove unused `BUNDLE_CONTAINERFILE_TEMPLATE` variable from the Makefile