### PR TITLE
Change nginx config env var to hardcoded value

### DIFF
--- a/templates/console-plugin.Dockerfile.template
+++ b/templates/console-plugin.Dockerfile.template
@@ -28,7 +28,7 @@ LABEL \
     License="Apache License 2.0"
 
 COPY --from=builder /opt/app-root/src/licenses/ /licenses/
-COPY --from=builder /opt/app-root/src/docker/etc/default.conf "${NGINX_CONFIGURATION_PATH}"
+COPY --from=builder /opt/app-root/src/docker/etc/default.conf /opt/app-root/etc/nginx.d/
 COPY --from=builder /opt/app-root/src/dist .
 USER 1001
 CMD /usr/libexec/s2i/run


### PR DESCRIPTION
Konflux build do not resolve the env variable properly and making the copy
to the wrong place.

## Summary by Sourcery

Bug Fixes:
- Replace unresolved NGINX_CONFIG_DIR environment variable with a hardcoded path in the console-plugin Dockerfile template to ensure proper config placement.