### PR TITLE
Drop pull secret bits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,3 @@
 # Ignore build and test binaries.
 bin/
 testbin/
-pull.txt
-**/pull.txt

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -26,9 +26,4 @@ esac
 
 go version
 
-touch internal/controller/pull.txt
-if [ -f "/run/secrets/pull" ]; then
-    cp -f /run/secrets/pull internal/controller/pull.txt
-fi
-
 GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go $EXTRA -ldflags="${LDFLAGS}" cmd/main.go

--- a/internal/controller/pull.go
+++ b/internal/controller/pull.go
@@ -1,8 +1,0 @@
-package controller
-
-import (
-	_ "embed"
-)
-
-//go:embed pull.txt
-var pull string

--- a/internal/controller/secret.go
+++ b/internal/controller/secret.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/TwiN/deepmerge"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,15 +61,6 @@ func getPullSecretContent(name, namespace string, ctx context.Context, full kube
 	return secData, nil
 }
 
-func getPullJson() []byte {
-	if pull == "" {
-		return nil
-	}
-	log.Log.Info("Adding pull from embedded file")
-
-	return []byte(pull)
-}
-
 func getDockerConfigSecretJSON(secret []byte) ([]byte, error) {
 	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", IBMREGISTRYUSER, secret)))
 	auths := map[string]any{
@@ -85,12 +75,7 @@ func getDockerConfigSecretJSON(secret []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	pullJSON := getPullJson()
-	if pullJSON == nil {
-		return authsJSON, nil
-	}
-	ret, err := deepmerge.JSON(authsJSON, getPullJson())
-	return ret, err
+	return authsJSON, nil
 }
 
 func updateEntitlementPullSecrets(secret []byte, ctx context.Context, full kubernetes.Interface, ns string) error {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,11 +3,6 @@ set -e -o pipefail
 
 VERSION=$(cat VERSION.txt)
 
-if [ ! -s "internal/controller/pull.txt" ]; then
-  echo "Error: pull.txt is empty." >&2
-  exit 1
-fi
-
 make USE_IMAGE_DIGESTS="" clean bundle generate manifests docker-build docker-push \
     bundle-build bundle-push \
     console-build console-push devicefinder-docker-build devicefinder-docker-push


### PR DESCRIPTION
## Summary by Sourcery

Remove embedded pull secret handling and clean up related code and scripts

Enhancements:
- Simplify Docker config secret JSON generation by removing pull secret merging

Build:
- Remove pull.txt manipulation from hack/build.sh
- Remove pull.txt validation from scripts/release.sh

Chores:
- Drop getPullJson function and remove deepmerge import
- Delete internal/controller/pull.go and related pull secret logic