### PR TITLE
Pass SCRIPT_RUNNER_IMAGE_REFERENCE to build-container task as ADDITIONAL_BASE_IMAGES

### DIFF
--- a/.tekton/console-plugin-0-1-on-pull-request.yaml
+++ b/.tekton/console-plugin-0-1-on-pull-request.yaml
@@ -257,6 +257,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/console-plugin-0-1-on-push.yaml
+++ b/.tekton/console-plugin-0-1-on-push.yaml
@@ -470,6 +470,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: image-digest
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - coverity-availability-check
       taskRef:

--- a/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
@@ -257,6 +257,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/controller-rhel9-operator-0-1-on-push.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-push.yaml
@@ -254,6 +254,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/devicefinder-0-1-on-pull-request.yaml
+++ b/.tekton/devicefinder-0-1-on-pull-request.yaml
@@ -259,6 +259,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/devicefinder-0-1-on-push.yaml
+++ b/.tekton/devicefinder-0-1-on-push.yaml
@@ -256,6 +256,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/operator-bundle-0-1-on-pull-request.yaml
+++ b/.tekton/operator-bundle-0-1-on-pull-request.yaml
@@ -257,6 +257,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/operator-bundle-0-1-on-push.yaml
+++ b/.tekton/operator-bundle-0-1-on-push.yaml
@@ -254,6 +254,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Pass SCRIPT_RUNNER_IMAGE_REFERENCE into build-container tasks as ADDITIONAL_BASE_IMAGES across console-plugin, controller-rhel9-operator, devicefinder, and operator-bundle pipelines for both pull-request and push triggers