### PR TITLE
Fix typo in task reference for SCRIPT_RUNNER_IMAGE_REFERENCE

### DIFF
--- a/.tekton/console-plugin-0-1-on-pull-request.yaml
+++ b/.tekton/console-plugin-0-1-on-pull-request.yaml
@@ -258,7 +258,8 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/console-plugin-0-1-on-push.yaml
+++ b/.tekton/console-plugin-0-1-on-push.yaml
@@ -471,7 +471,8 @@ spec:
       - name: image-digest
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - coverity-availability-check
       taskRef:

--- a/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
@@ -258,7 +258,8 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/controller-rhel9-operator-0-1-on-push.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-push.yaml
@@ -255,7 +255,8 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/devicefinder-0-1-on-pull-request.yaml
+++ b/.tekton/devicefinder-0-1-on-pull-request.yaml
@@ -260,7 +260,8 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/devicefinder-0-1-on-push.yaml
+++ b/.tekton/devicefinder-0-1-on-push.yaml
@@ -257,7 +257,8 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/operator-bundle-0-1-on-pull-request.yaml
+++ b/.tekton/operator-bundle-0-1-on-pull-request.yaml
@@ -258,7 +258,8 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/operator-bundle-0-1-on-push.yaml
+++ b/.tekton/operator-bundle-0-1-on-push.yaml
@@ -255,7 +255,8 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: ADDITIONAL_BASE_IMAGES
-        value: $(task.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+        value:
+        - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Fix typo in Tekton pipeline YAMLs by replacing task.generate-dockerfile with tasks.generate-dockerfile for SCRIPT_RUNNER_IMAGE_REFERENCE in on-pull-request and on-push configs