### PR TITLE
Test a thing

### DIFF
--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -453,7 +453,7 @@ data:
 			Expect(matches).ToNot(BeEmpty())
 
 			for _, match := range matches {
-				fmt.Printf("Checking for image in file: %s -> ", match)
+				GinkgoWriter.Printf("Checking for image in file: %s -> ", match)
 				yaml, err := os.ReadFile(match)
 				Expect(err).NotTo(HaveOccurred())
 				result, err := ParseYAMLAndExtractTestImage(string(yaml))


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Use GinkgoWriter.Printf in utils_test.go in place of fmt.Printf to ensure test output is captured by Ginkgo