### PR TITLE
Use digest 1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d for task-run-script-oci-ta to fix build script issue

### DIFF
--- a/.tekton/console-plugin-common.yaml
+++ b/.tekton/console-plugin-common.yaml
@@ -169,7 +169,7 @@ spec:
       - name: name
         value: run-script-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:4b4012ad649a0354a7a355a9b26c0b53bea577801bcaf903dc5260321a9e3c3a
+        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/controller-rhel9-operator-common.yaml
+++ b/.tekton/controller-rhel9-operator-common.yaml
@@ -169,7 +169,7 @@ spec:
       - name: name
         value: run-script-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:4b4012ad649a0354a7a355a9b26c0b53bea577801bcaf903dc5260321a9e3c3a
+        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/devicefinder-common.yaml
+++ b/.tekton/devicefinder-common.yaml
@@ -169,7 +169,7 @@ spec:
       - name: name
         value: run-script-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:4b4012ad649a0354a7a355a9b26c0b53bea577801bcaf903dc5260321a9e3c3a
+        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/operator-bundle-common.yaml
+++ b/.tekton/operator-bundle-common.yaml
@@ -173,7 +173,7 @@ spec:
       - name: name
         value: run-script-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:4b4012ad649a0354a7a355a9b26c0b53bea577801bcaf903dc5260321a9e3c3a
+        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary by Sourcery

Update Tekton pipeline YAMLs to reference new OCI bundle digests for consistency and fix build script issues, unify quoting style, and enhance apply-tags task parameters.

Bug Fixes:
- Use updated digest for task-run-script-oci-ta to resolve build script error.

Enhancements:
- Update SHA256 digests for multiple Tekton catalog tasks across common pipeline definitions.
- Standardize default parameter quoting in YAML manifests from double quotes to single quotes.
- Extend the apply-tags task to accept both IMAGE_URL and IMAGE_DIGEST parameters instead of a single IMAGE parameter.