### PR TITLE
Revert workaround to avoid problems with the SCRIPT_RUNNER_IMAGE_REFERENCE parameter being wrongly formatted that caused the ECP violations

### DIFF
--- a/.tekton/console-plugin-common.yaml
+++ b/.tekton/console-plugin-common.yaml
@@ -80,10 +80,6 @@ spec:
     description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
-  - description: Script base image
-    name: script-base-image
-    default: "quay.io/konflux-ci/operator-sdk-builder:latest@sha256:df11e9d5193d267f9c92061ef132b4c2f80e70642ae4fb5f40ade46405970559"
-    type: string
   results:
   - description: ''
     name: IMAGE_URL
@@ -157,7 +153,7 @@ spec:
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: SCRIPT_RUNNER_IMAGE
-      value: $(params.script-base-image)
+      value: quay.io/konflux-ci/operator-sdk-builder:latest
     runAfter:
     - clone-repository
     taskRef:
@@ -224,7 +220,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - $(params.script-base-image)
+      - "quay.io/konflux-ci/operator-sdk-builder:latest"
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/console-plugin-common.yaml
+++ b/.tekton/console-plugin-common.yaml
@@ -220,7 +220,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - "quay.io/konflux-ci/operator-sdk-builder:latest"
+      - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/controller-rhel9-operator-common.yaml
+++ b/.tekton/controller-rhel9-operator-common.yaml
@@ -80,10 +80,6 @@ spec:
     description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
-  - description: Script base image
-    name: script-base-image
-    default: "quay.io/konflux-ci/operator-sdk-builder:latest@sha256:df11e9d5193d267f9c92061ef132b4c2f80e70642ae4fb5f40ade46405970559"
-    type: string
   results:
   - description: ''
     name: IMAGE_URL
@@ -157,7 +153,7 @@ spec:
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: SCRIPT_RUNNER_IMAGE
-      value: $(params.script-base-image)
+      value: quay.io/konflux-ci/operator-sdk-builder:latest
     runAfter:
     - clone-repository
     taskRef:
@@ -224,7 +220,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - $(params.script-base-image)
+      - "quay.io/konflux-ci/operator-sdk-builder:latest"
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/controller-rhel9-operator-common.yaml
+++ b/.tekton/controller-rhel9-operator-common.yaml
@@ -220,7 +220,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - "quay.io/konflux-ci/operator-sdk-builder:latest"
+      - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/devicefinder-common.yaml
+++ b/.tekton/devicefinder-common.yaml
@@ -222,7 +222,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - "quay.io/konflux-ci/operator-sdk-builder:latest"
+      - $(tasks.generate-dockerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/devicefinder-common.yaml
+++ b/.tekton/devicefinder-common.yaml
@@ -80,10 +80,6 @@ spec:
     description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
-  - description: Script base image
-    name: script-base-image
-    default: "quay.io/konflux-ci/operator-sdk-builder:latest@sha256:df11e9d5193d267f9c92061ef132b4c2f80e70642ae4fb5f40ade46405970559"
-    type: string
   results:
   - description: ''
     name: IMAGE_URL
@@ -157,7 +153,7 @@ spec:
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: SCRIPT_RUNNER_IMAGE
-      value: $(params.script-base-image)
+      value: quay.io/konflux-ci/operator-sdk-builder:latest
     runAfter:
     - clone-repository
     taskRef:
@@ -226,7 +222,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - $(params.script-base-image)
+      - "quay.io/konflux-ci/operator-sdk-builder:latest"
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/operator-bundle-common.yaml
+++ b/.tekton/operator-bundle-common.yaml
@@ -84,10 +84,6 @@ spec:
     description: Whether to enable privileged mode, should be used only with remote VMs
     name: privileged-nested
     type: string
-  - description: Script base image
-    name: script-base-image
-    default: "quay.io/konflux-ci/operator-sdk-builder:latest@sha256:df11e9d5193d267f9c92061ef132b4c2f80e70642ae4fb5f40ade46405970559"
-    type: string
   results:
   - description: ''
     name: IMAGE_URL
@@ -161,7 +157,7 @@ spec:
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: SCRIPT_RUNNER_IMAGE
-      value: $(params.script-base-image)
+      value: quay.io/konflux-ci/operator-sdk-builder:latest
     runAfter:
     - clone-repository
     taskRef:
@@ -228,7 +224,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - $(params.script-base-image)
+      - "quay.io/konflux-ci/operator-sdk-builder:latest"
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/.tekton/operator-bundle-common.yaml
+++ b/.tekton/operator-bundle-common.yaml
@@ -224,7 +224,7 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: ADDITIONAL_BASE_IMAGES
       value:
-      - "quay.io/konflux-ci/operator-sdk-builder:latest"
+      - $(tasks.generate-bundle.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
     runAfter:
     - prefetch-dependencies
     taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Revert the workaround that introduced a redundant script-base-image parameter by removing the parameter and restoring direct use of the generated SCRIPT_RUNNER_IMAGE_REFERENCE and literal builder image in Tekton pipeline definitions.

Bug Fixes:
- Remove the obsolete script-base-image parameter and its default value from all common Tekton task definitions
- Set SCRIPT_RUNNER_IMAGE to a fixed quay.io builder image instead of using the removed parameter
- Update ADDITIONAL_BASE_IMAGES to pull the image reference from tasks.generate-…results.SCRIPT_RUNNER_IMAGE_REFERENCE