### PR TITLE
Try and force a minimum kmm version via olm.package

### DIFF
--- a/config/olm-dependencies.yaml
+++ b/config/olm-dependencies.yaml
@@ -1,6 +1,5 @@
 dependencies:
-- type: olm.gvk
+- type: olm.package
   value:
-    group: kmm.sigs.x-k8s.io
-    kind: Module
-    version: v1beta1
+    packageName: kernel-module-management
+    version: ">=2.4.0"


### PR DESCRIPTION
See
https://olm.operatorframework.io/docs/concepts/olm-architecture/dependency-resolution/

kmm < 2.4.0 are affected by a bug when using a secret to pull and push
images during the build

## Summary by Sourcery

Update OLM dependencies to use package-based resolution and require kernel-module-management version 2.4.0 or higher to avoid a known secret handling bug

Bug Fixes:
- Enforce kmm operator version >=2.4.0 to work around the build secret pull/push bug in earlier versions

Enhancements:
- Switch OLM dependency from olm.gvk to olm.package in olm-dependencies.yaml