### PR TITLE
Truncate the image hash

### DIFF
--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -123,6 +123,13 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 	var selector map[string]string
 
 	ibmImageHash := getIBMCoreImageHash(ibmScaleImage)
+
+	// We need to truncate the image hash so the module image tag fits into 128 chars, otherwise it is an invalid docker reference
+	const maxHashLength = 32
+	if len(ibmImageHash) > maxHashLength {
+		ibmImageHash = ibmImageHash[:maxHashLength]
+	}
+
 	ibmImageHashLabel := getIBMCoreImageHashForLabel(ibmScaleImage)
 	if ibmImageHashLabel != "" {
 		selector = map[string]string{


### PR DESCRIPTION
We need to truncate the image hash so the module image tag fits into 128
chars. Otherwise it is an invalid docker reference.

## Summary by Sourcery

Bug Fixes:
- Limit the image hash to 32 characters to prevent exceeding Docker's 128-character tag limit