### PR TITLE
Add release-4.19 to the tekton triggers

### DIFF
--- a/.tekton/console-plugin-0-1-on-pull-request.yaml
+++ b/.tekton/console-plugin-0-1-on-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "release-4.19") && (
       "console/***".pathChanged() ||
       "VERSION.txt".pathChanged() ||
       ".tekton/console-plugin-0-1-on-pull-request.yaml".pathChanged() ||

--- a/.tekton/console-plugin-0-1-on-push.yaml
+++ b/.tekton/console-plugin-0-1-on-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch== "main" && (
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch == "main" || target_branch == "release-4.19") && (
       "console/***".pathChanged() ||
       "VERSION.txt".pathChanged() ||
       ".tekton/console-plugin-0-1-on-push.yaml".pathChanged() ||

--- a/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "release-4.19") && (
       "go.mod".pathChanged() ||
       "VERSION.txt".pathChanged() ||
       "cmd/main.go".pathChanged() ||

--- a/.tekton/controller-rhel9-operator-0-1-on-push.yaml
+++ b/.tekton/controller-rhel9-operator-0-1-on-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch == "main" || target_branch == "release-4.19") && (
       "go.mod".pathChanged() ||
       "VERSION.txt".pathChanged() ||
       "cmd/main.go".pathChanged() ||

--- a/.tekton/devicefinder-0-1-on-pull-request.yaml
+++ b/.tekton/devicefinder-0-1-on-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && (
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "release-4.19") && (
       "go.mod".pathChanged() ||
       "VERSION.txt".pathChanged() ||
       "cmd/devicefinder/***".pathChanged() ||

--- a/.tekton/devicefinder-0-1-on-push.yaml
+++ b/.tekton/devicefinder-0-1-on-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && (
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch == "main" || target_branch == "release-4.19") && (
       "go.mod".pathChanged() ||
       "VERSION.txt".pathChanged() ||
       "cmd/devicefinder/***".pathChanged() ||

--- a/.tekton/operator-bundle-0-1-on-pull-request.yaml
+++ b/.tekton/operator-bundle-0-1-on-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "release-4.19") && (
       ("templates/bundle.Dockerfile.template".pathChanged() ||
       ".tekton/operator-bundle-0-1-on-pull-request.yaml".pathChanged() ||
       ".tekton/operator-bundle-common.yaml".pathChanged() ||

--- a/.tekton/operator-bundle-0-1-on-push.yaml
+++ b/.tekton/operator-bundle-0-1-on-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch == "main" || target_branch == "release-4.19") &&
       ("templates/bundle.Dockerfile.template".pathChanged() ||
       ".tekton/operator-bundle-0-1-on-push.yaml".pathChanged() ||
       ".tekton/operator-bundle-common.yaml".pathChanged() ||


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add release-4.19 as an accepted target_branch in the CEL expression filters for pull_request and push triggers across all .tekton pipeline configurations (console-plugin, controller-rhel9-operator, devicefinder, and operator-bundle).