### PR TITLE
refactor: replace showAlert with addAlert in global state management

### DIFF
--- a/console/src/constants.ts
+++ b/console/src/constants.ts
@@ -14,7 +14,5 @@ export const STORAGE_ROLE_LABEL = "scale.spectrum.ibm.com/role=storage";
 export const WORKER_NODE_ROLE_LABEL = "node-role.kubernetes.io/worker=";
 export const MASTER_NODE_ROLE_LABEL = "node-role.kubernetes.io/master=";
 export const CPLANE_NODE_ROLE_LABEL = "node-role.kubernetes.io/control-plane=";
-export const MIN_AMOUNT_OF_NODES_MSG_DIGEST =
-  "5da6449cd9450de311ce1e19f6a9a01be8710958";
 export const FS_ALLOW_DELETE_LABEL = "scale.spectrum.ibm.com/allowDelete";
 export const SC_PROVISIONER = "spectrumscale.csi.ibm.com";

--- a/console/src/features/file-systems/hooks/useCreateFileSystemHandler.ts
+++ b/console/src/features/file-systems/hooks/useCreateFileSystemHandler.ts
@@ -50,11 +50,11 @@ export const useCreateFileSystemHandler = (
   return useCallback(async () => {
     if (!luns.nodeName) {
       dispatch({
-        type: "global/showAlert",
+        type: "global/addAlert",
         payload: {
           title: "Node name is required to create a file system.",
-          isDismissable: true,
           variant: "warning",
+          dismiss: () => dispatch({ type: "global/dismissAlert" }),
         },
       });
       return;
@@ -85,12 +85,11 @@ export const useCreateFileSystemHandler = (
     } catch (e) {
       const description = e instanceof Error ? e.message : (e as string);
       dispatch({
-        type: "global/showAlert",
+        type: "global/addAlert",
         payload: {
-          variant: "danger",
           title: t("An error occurred while creating resources"),
           description,
-          isDismissable: true,
+          variant: "danger",
         },
       });
     } finally {

--- a/console/src/features/file-systems/hooks/useLunsViewModel.ts
+++ b/console/src/features/file-systems/hooks/useLunsViewModel.ts
@@ -25,13 +25,12 @@ export const useLunsViewModel = () => {
   useEffect(() => {
     if (storageNodesLvdrs.error) {
       dispatch({
-        type: "global/showAlert",
+        type: "global/addAlert",
         payload: {
           title: t(
             "Failed to load LocaVolumeDiscoveryResults for storage nodes"
           ),
           description: storageNodesLvdrs.error.message,
-          isDismissable: true,
           variant: "danger",
         },
       });

--- a/console/src/features/file-systems/pages/FileSystemsCreatePage.tsx
+++ b/console/src/features/file-systems/pages/FileSystemsCreatePage.tsx
@@ -24,7 +24,7 @@ FileSystemsCreate.displayName = "FileSystemsCreate";
 export default FileSystemsCreate;
 
 const ConnectedCreateFileSystems: React.FC = () => {
-  const [store, dispatch] = useStore<State, Actions>();
+  const [store] = useStore<State, Actions>();
 
   const { t } = useFusionAccessTranslations();
 
@@ -39,8 +39,7 @@ const ConnectedCreateFileSystems: React.FC = () => {
       description={t(
         "Create a file system to represent your required storage (based on the selected nodes’ storage)."
       )}
-      alert={store.alert}
-      onDismissAlert={() => dispatch({ type: "global/dismissAlert" })}
+      alerts={store.alerts}
       footer={
         <Split hasGutter>
           <FileSystemsCreateButton

--- a/console/src/features/file-systems/pages/FileSystemsHomePage.tsx
+++ b/console/src/features/file-systems/pages/FileSystemsHomePage.tsx
@@ -32,7 +32,7 @@ export default FileSystemsHomePage;
 const ConnectedFileSystemsHomePage: React.FC = () => {
   const { t } = useFusionAccessTranslations();
 
-  const [store, dispatch] = useStore<State, Actions>();
+  const [store] = useStore<State, Actions>();
 
   const storageClusters = useWatchStorageCluster({ limit: 1 });
 
@@ -46,8 +46,7 @@ const ConnectedFileSystemsHomePage: React.FC = () => {
     <ListPage
       documentTitle={t("Fusion Access for SAN")}
       title={t("Fusion Access for SAN")}
-      alert={store.alert}
-      onDismissAlert={() => dispatch({ type: "global/dismissAlert" })}
+      alerts={store.alerts}
       actions={
         (fileSystems.data ?? []).length > 0 ? (
           <FileSystemsCreateButton onClick={redirectToCreateFileSystems} />

--- a/console/src/features/storage-clusters/hooks/useCreateStorageClusterHandler.ts
+++ b/console/src/features/storage-clusters/hooks/useCreateStorageClusterHandler.ts
@@ -53,12 +53,11 @@ export const useCreateStorageClusterHandler = () => {
     } catch (e) {
       const description = e instanceof Error ? e.message : (e as string);
       dispatch({
-        type: "global/showAlert",
+        type: "global/addAlert",
         payload: {
-          variant: "danger",
           title: t("An error occurred while creating resources"),
           description,
-          isDismissable: true,
+          variant: "danger",
         },
       });
     }

--- a/console/src/features/storage-clusters/hooks/useValidateMinimumRequirements.ts
+++ b/console/src/features/storage-clusters/hooks/useValidateMinimumRequirements.ts
@@ -1,20 +1,22 @@
 import {
   MINIMUM_AMOUNT_OF_SHARED_DISKS,
   MINIMUM_AMOUNT_OF_NODES,
-  MIN_AMOUNT_OF_NODES_MSG_DIGEST,
   MINIMUM_AMOUNT_OF_SHARED_DISKS_LITERAL,
   MINIMUM_AMOUNT_OF_NODES_LITERAL,
 } from "@/constants";
 import { useFusionAccessTranslations } from "@/shared/hooks/useFusionAccessTranslations";
 import { useStore } from "@/shared/store/provider";
 import type { State, Actions } from "@/shared/store/types";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { NodesSelectionTableViewModel } from "./useNodesSelectionTableViewModel";
 
 export const useValidateMinimumRequirements = (
   vm: NodesSelectionTableViewModel
 ) => {
-  const [, dispatch] = useStore<State, Actions>();
+  const [store, dispatch] = useStore<State, Actions>();
+  const storeRef = useRef(store);
+  storeRef.current = store;
+
   const { t } = useFusionAccessTranslations();
 
   useEffect(() => {
@@ -33,10 +35,9 @@ export const useValidateMinimumRequirements = (
         payload: { isDisabled: true },
       });
       dispatch({
-        type: "global/showAlert",
+        type: "global/addAlert",
         payload: {
-          key: MIN_AMOUNT_OF_NODES_MSG_DIGEST,
-          variant: "warning",
+          key: "minimum-shared-disks-and-nodes",
           title: t("Storage cluster requirements"),
           description: [
             conditions[0]
@@ -54,7 +55,8 @@ export const useValidateMinimumRequirements = (
                 )
               : "",
           ].filter(Boolean),
-          isDismissable: false,
+          variant: "warning",
+          dismiss: () => dispatch({ type: "global/dismissAlert" }),
         },
       });
     } else {
@@ -62,9 +64,9 @@ export const useValidateMinimumRequirements = (
         type: "global/updateCta",
         payload: { isDisabled: false },
       });
-      dispatch({
-        type: "global/dismissAlert",
-      });
+      storeRef.current.alerts
+        .find((alert) => alert.key === "minimum-shared-disks-and-nodes")
+        ?.dismiss!();
     }
   }, [dispatch, t, vm.loaded, vm.selectedNodes.length, vm.sharedDisksCount]);
 };

--- a/console/src/features/storage-clusters/pages/StorageClusterCreatePage.tsx
+++ b/console/src/features/storage-clusters/pages/StorageClusterCreatePage.tsx
@@ -33,7 +33,7 @@ export default StorageClusterCreate;
 
 const ConnectedStorageClusterCreate: React.FC = () => {
   const { t } = useFusionAccessTranslations();
-  const [store, dispatch] = useStore<State, Actions>();
+  const [store] = useStore<State, Actions>();
   const handleCreateStorageCluster = useCreateStorageClusterHandler();
   const redirectoStorageClusterHome = useRedirectHandler(
     "/fusion-access/storage-cluster"
@@ -43,8 +43,7 @@ const ConnectedStorageClusterCreate: React.FC = () => {
     <ListPage
       documentTitle={t("Fusion Access for SAN")}
       title={t("Create storage cluster")}
-      alert={store.alert}
-      onDismissAlert={() => dispatch({ type: "global/dismissAlert" })}
+      alerts={store.alerts}
       footer={
         <Split hasGutter>
           <StorageClustersCreateButton

--- a/console/src/features/storage-clusters/pages/StorageClusterHomePage.tsx
+++ b/console/src/features/storage-clusters/pages/StorageClusterHomePage.tsx
@@ -31,7 +31,7 @@ export default StorageClusterHomePage;
 const ConnectedStorageClusterHomePage: React.FC = () => {
   const { t } = useFusionAccessTranslations();
 
-  const [store, dispatch] = useStore<State, Actions>();
+  const [store] = useStore<State, Actions>();
 
   const redirectToCreateStorageCluster = useRedirectHandler(
     "/fusion-access/storage-cluster/create"
@@ -43,8 +43,7 @@ const ConnectedStorageClusterHomePage: React.FC = () => {
     <ListPage
       documentTitle={t("Fusion Access for SAN")}
       title={t("Fusion Access for SAN")}
-      alert={store.alert}
-      onDismissAlert={() => dispatch({ type: "global/dismissAlert" })}
+      alerts={store.alerts}
     >
       <Async
         loaded={storageClusters.loaded}

--- a/console/src/shared/components/ListPage.tsx
+++ b/console/src/shared/components/ListPage.tsx
@@ -3,25 +3,17 @@ import {
   ListPageBody,
   ListPageHeader,
 } from "@openshift-console/dynamic-plugin-sdk";
-import {
-  AlertGroup,
-  Alert,
-  AlertActionCloseButton,
-  Stack,
-  StackItem,
-  List,
-  ListItem,
-} from "@patternfly/react-core";
+import { Stack, StackItem } from "@patternfly/react-core";
 import { useLayoutEffect } from "react";
 import type { State } from "../store/types";
+import { ListPageAlert } from "./ListPageAlert";
 
 interface ListPageProps {
   documentTitle: string;
   title: string;
   description?: React.ReactNode;
   actions?: React.ReactNode;
-  alert?: State['alert'];
-  onDismissAlert?: (alert: State['alert']) => void;
+  alerts?: State["alerts"];
   listPageBodyStyle?: Partial<UseListPageBodyStyleHackOptions>;
   footer?: React.ReactNode;
 }
@@ -29,12 +21,11 @@ interface ListPageProps {
 export const ListPage: React.FC<ListPageProps> = (props) => {
   const {
     actions,
-    alert,
+    alerts = [],
     children,
     description = <br />,
     documentTitle,
     listPageBodyStyle = {},
-    onDismissAlert,
     title,
     footer,
   } = props;
@@ -55,38 +46,7 @@ export const ListPage: React.FC<ListPageProps> = (props) => {
         <Stack hasGutter>
           <StackItem>{children}</StackItem>
           <StackItem isFilled style={{ alignContent: "flex-end" }}>
-            {alert && (
-              <AlertGroup isLiveRegion>
-                <Alert
-                  isInline
-                  key={alert.key}
-                  variant={alert.variant}
-                  title={alert.title}
-                  actionClose={
-                    alert.isDismissable ? (
-                      <AlertActionCloseButton
-                        title={alert.title as string}
-                        variantLabel={alert.variant}
-                        onClose={() => {
-                          onDismissAlert?.(alert);
-                        }}
-                      />
-                    ) : null
-                  }
-                >
-                  {alert.description &&
-                  typeof alert.description !== "string" ? (
-                    <List>
-                      {alert.description.map((desc, idx) => (
-                        <ListItem key={idx}>{desc}</ListItem>
-                      ))}
-                    </List>
-                  ) : (
-                    alert.description
-                  )}
-                </Alert>
-              </AlertGroup>
-            )}
+            <ListPageAlert alert={alerts[0]} />
           </StackItem>
           <StackItem>{footer}</StackItem>
         </Stack>

--- a/console/src/shared/components/ListPageAlert.tsx
+++ b/console/src/shared/components/ListPageAlert.tsx
@@ -1,0 +1,50 @@
+import type { AlertProps } from "@patternfly/react-core/dist/esm/components/Alert/Alert";
+import {
+  AlertGroup,
+  Alert,
+  AlertActionCloseButton,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+
+export interface Alert extends Pick<AlertProps, "key" | "variant" | "title"> {
+  description?: string | string[];
+  dismiss?: VoidFunction;
+}
+
+type ListPageAlertProps = { alert?: Alert };
+
+export const ListPageAlert: React.FC<ListPageAlertProps> = (props) => {
+  const { alert } = props;
+
+  return alert ? (
+    <AlertGroup isLiveRegion>
+      <Alert
+        isInline
+        key={alert.key}
+        variant={alert.variant}
+        title={alert.title}
+        actionClose={
+          alert.dismiss ? (
+            <AlertActionCloseButton
+              title={alert.title as string}
+              variantLabel={alert.variant}
+              onClose={alert.dismiss}
+            />
+          ) : null
+        }
+      >
+        {alert.description && typeof alert.description !== "string" ? (
+          <List>
+            {alert.description.map((desc, idx) => (
+              <ListItem key={idx}>{desc}</ListItem>
+            ))}
+          </List>
+        ) : (
+          alert.description
+        )}
+      </Alert>
+    </AlertGroup>
+  ) : null;
+};
+ListPageAlert.displayName = "ListPageAlert";

--- a/console/src/shared/store/reducer.ts
+++ b/console/src/shared/store/reducer.ts
@@ -11,11 +11,31 @@ export const reducer: ImmerReducer<State, Actions> = (draft, action) => {
     case "global/updateDocTitle":
       draft.docTitle = action.payload;
       break;
-    case "global/showAlert":
-      draft.alert = action.payload;
+    case "global/addAlert":
+      if (action.payload.key === "minimum-shared-disks-and-nodes") {
+        // If the alert for minimum shared disks and nodes already exists,
+        // we don't add it again, but we update the existing one.
+        const existingAlertIndex = draft.alerts.findIndex(
+          (a) => a.key === "minimum-shared-disks-and-nodes"
+        );
+
+        if (existingAlertIndex === -1) {
+          // If the alert does not exist, we add it to the front.
+          draft.alerts.unshift(action.payload);
+        } else if (existingAlertIndex === 0) {
+          draft.alerts[existingAlertIndex] = action.payload;
+        } else if (existingAlertIndex > 0) {
+          // If the alert is not the first one, we move it to the front
+          // to ensure it is always visible.
+          draft.alerts.splice(existingAlertIndex, 1);
+          draft.alerts.unshift(action.payload);
+        }
+      } else {
+        draft.alerts.push(action.payload);
+      }
       break;
     case "global/dismissAlert":
-      draft.alert = null;
+      draft.alerts.shift();
       break;
     case "global/updateCta":
       draft.cta = {
@@ -32,7 +52,7 @@ export const reducer: ImmerReducer<State, Actions> = (draft, action) => {
 
 export const initialState: State = {
   docTitle: t("Fusion Access for SAN"),
-  alert: null,
+  alerts: [],
   cta: {
     isDisabled: true,
     isLoading: false,

--- a/console/src/shared/store/types.ts
+++ b/console/src/shared/store/types.ts
@@ -1,20 +1,15 @@
-import type { AlertProps } from "@patternfly/react-core/dist/esm/components/Alert/Alert";
+import type { Alert } from "@/shared/components/ListPageAlert";
 import type { ActionDef } from "./provider";
 
 export type Actions =
   | ActionDef<"global/updateDocTitle", State["docTitle"]>
-  | ActionDef<"global/showAlert", State["alert"]>
+  | ActionDef<"global/addAlert", Alert>
   | ActionDef<"global/dismissAlert">
   | ActionDef<"global/updateCta", Partial<State["cta"]>>;
 
 export interface State {
   docTitle: string;
-  alert:
-    | (Pick<AlertProps, "key" | "variant" | "title"> & {
-        description?: string | string[];
-        isDismissable?: boolean;
-      })
-    | null;
+  alerts: Array<Alert>;
   cta: {
     isDisabled?: boolean;
     isLoading?: boolean;


### PR DESCRIPTION
- Updated alert handling to use addAlert instead of showAlert for better alert management.
- Refactored components to accommodate the new alerts structure.
- Introduced ListPageAlert component for improved alert display.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>

## Summary by Sourcery

Migrate the global alert system from a single showAlert model to a multi-alert addAlert approach, introduce a reusable ListPageAlert component, and update reducer, state, types, components, and hooks to use the new alert structure.

New Features:
- Introduce ListPageAlert component for inline, dismissable alerts
- Add global addAlert action to queue and manage multiple alerts

Enhancements:
- Migrate reducer, state, and types to handle an alerts array instead of a single alert
- Refactor ListPage and page components to render alerts via ListPageAlert and replace alert/onDismissAlert props with alerts
- Update hooks (storage clusters, nodes selection, file systems) to dispatch addAlert for errors and validations with dismiss callbacks