### PR TITLE
refactor: update file system and LUN properties for clarity and consistency

### DIFF
--- a/console/src/features/file-systems/components/FileSystemCreateForm.tsx
+++ b/console/src/features/file-systems/components/FileSystemCreateForm.tsx
@@ -29,7 +29,7 @@ export const FileSystemCreateForm: React.FC = () => {
           id="file-system-create-form"
           onSubmit={vm.handleSubmitForm}
         >
-          <FormGroup isRequired label="Name" fieldId="name">
+          <FormGroup isRequired label="File system name" fieldId="name">
             <TextInput
               type="text"
               id="name"
@@ -90,7 +90,7 @@ export const FileSystemCreateForm: React.FC = () => {
                 </Thead>
                 <Tbody>
                   {vm.luns.data.map((lun, rowIndex) => (
-                    <Tr key={lun.id}>
+                    <Tr key={lun.path}>
                       <Td
                         select={{
                           rowIndex,
@@ -98,8 +98,8 @@ export const FileSystemCreateForm: React.FC = () => {
                           onSelect: vm.handleSelectLun(lun),
                         }}
                       />
-                      <Td dataLabel={vm.columns.ID}>{lun.id}</Td>
-                      <Td dataLabel={vm.columns.NAME}>{lun.name}</Td>
+                      <Td dataLabel={vm.columns.PATH}>{lun.path}</Td>
+                      <Td dataLabel={vm.columns.WWN}>{lun.wwn}</Td>
                       <Td dataLabel={vm.columns.CAPACITY}>{lun.capacity}</Td>
                     </Tr>
                   ))}

--- a/console/src/features/file-systems/components/FileSystemsDeleteModal.tsx
+++ b/console/src/features/file-systems/components/FileSystemsDeleteModal.tsx
@@ -35,7 +35,7 @@ export const FileSystemsDeleteModal: React.FC<FileSystemsDeleteModalProps> = (
       onClose={vm.handleClose}
     >
       <ModalHeader
-        title={t("Delete Filesystem")}
+        title={t("Delete File system")}
         titleIconVariant="warning"
         labelId="delete-filesystem-title"
       />
@@ -83,7 +83,7 @@ export const FileSystemsDeleteModal: React.FC<FileSystemsDeleteModalProps> = (
             isLoading={vm.isDeleting}
             isDisabled={vm.isDeleting}
           >
-            {vm.isDeleting ? t("Deleting") : t("Confirm")}
+            {vm.isDeleting ? t("Deleting") : t("Delete")}
           </Button>
         ) : (
           <Button
@@ -94,7 +94,7 @@ export const FileSystemsDeleteModal: React.FC<FileSystemsDeleteModalProps> = (
             isLoading={vm.isDeleting}
             isDisabled={vm.isDeleting}
           >
-            {t("OK")}
+            {t("Close")}
           </Button>
         )}
         {vm.isDeleting ? null : (

--- a/console/src/features/file-systems/components/FileSystemsTableEmptyState.tsx
+++ b/console/src/features/file-systems/components/FileSystemsTableEmptyState.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   EmptyState,
   EmptyStateActions,
-  EmptyStateBody,
   EmptyStateFooter,
 } from "@patternfly/react-core";
 import { ExternalLinkAltIcon, FolderIcon } from "@patternfly/react-icons";
@@ -23,9 +22,6 @@ export const FileSystemsTableEmptyState: React.FC = () => {
       headingLevel="h4"
       icon={FolderIcon}
     >
-      <EmptyStateBody>
-        {t("You can create one by pressing the button below.")}
-      </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
           <FileSystemsCreateButton onClick={redirectToCreateFileSystem} />

--- a/console/src/features/file-systems/hooks/useCreateFileSystemHandler.ts
+++ b/console/src/features/file-systems/hooks/useCreateFileSystemHandler.ts
@@ -149,7 +149,7 @@ function createLocalDisks(
   const promises: Promise<LocalDisk>[] = [];
   for (const lun of luns.data) {
     const localDiskName =
-      `${lun.id.slice("/dev/".length)}-${lun.name}`.replaceAll(".", "-");
+      `${lun.path.slice("/dev/".length)}-${lun.wwn}`.replaceAll(".", "-");
     const promise = k8sCreate<LocalDisk>({
       model: localDiskModel,
       data: {
@@ -157,7 +157,7 @@ function createLocalDisks(
         kind: "LocalDisk",
         metadata: { name: localDiskName, namespace },
         spec: {
-          device: lun.id,
+          device: lun.path,
           node: luns.nodeName!,
         },
       },

--- a/console/src/features/file-systems/hooks/useFileSystemCreateFormViewModel.ts
+++ b/console/src/features/file-systems/hooks/useFileSystemCreateFormViewModel.ts
@@ -18,8 +18,8 @@ export const useFileSystemCreateFormViewModel = () => {
   const columns = useMemo(
     () =>
       ({
-        ID: t("ID"),
-        NAME: t("Name"),
+        PATH: t("Path"),
+        WWN: t("WWN"),
         CAPACITY: t("Capacity"),
       }) as const,
     [t]

--- a/console/src/features/file-systems/hooks/useLunsViewModel.ts
+++ b/console/src/features/file-systems/hooks/useLunsViewModel.ts
@@ -10,8 +10,8 @@ import type { LocalDisk } from "@/shared/types/ibm-spectrum-scale/LocalDisk";
 
 export interface Lun {
   isSelected: boolean;
-  id: string;
-  name: string;
+  path: string;
+  wwn: string;
   capacity: string;
 }
 
@@ -70,14 +70,14 @@ export const useLunsViewModel = () => {
   ]);
 
   const isSelected = useCallback(
-    (lun: Lun) => luns.find((l) => l.id === lun.id)?.isSelected ?? false,
+    (lun: Lun) => luns.find((l) => l.path === lun.path)?.isSelected ?? false,
     [luns]
   );
 
   const setSelected = useCallback((lun: Lun, isSelected: boolean) => {
     setLuns((current) => {
       const draft = window.structuredClone(current);
-      const subject = draft.find((l) => l.id === lun.id);
+      const subject = draft.find((l) => l.path === lun.path);
       if (subject) {
         subject.isSelected = isSelected;
         return draft;
@@ -130,8 +130,8 @@ const outDevicesUsedByLocalDisks =
 const toLun = (disk: DiscoveredDevice): Lun => {
   return {
     isSelected: false,
-    id: disk.path,
-    name: disk.WWN.slice("uuid.".length),
+    path: disk.path,
+    wwn: disk.WWN.slice("uuid.".length),
     // Note: Usage of 'GB' is intentional here
     capacity: convert(disk.size, "B").to("GiB").toFixed(2) + " GB",
   };

--- a/console/src/features/storage-clusters/components/NodesSelectionTable.tsx
+++ b/console/src/features/storage-clusters/components/NodesSelectionTable.tsx
@@ -9,7 +9,6 @@ import {
   Stack,
   StackItem,
 } from "@patternfly/react-core";
-import { InfoIcon } from "@patternfly/react-icons";
 import { useFusionAccessTranslations } from "@/shared/hooks/useFusionAccessTranslations";
 import type { IoK8sApiCoreV1Node } from "@/shared/types/kubernetes/1.30/types";
 import { useNodesSelectionTableViewModel } from "../hooks/useNodesSelectionTableViewModel";
@@ -28,7 +27,7 @@ export const NodesSelectionTable: React.FC = () => {
           isInline
           variant="info"
           title={t(
-            "Make sure all nodes for the storage cluster are selected before you continue."
+            "Make sure all nodes for the storage cluster are selected before you continue (at least three nodes are required)."
           )}
         />
       </StackItem>
@@ -46,7 +45,7 @@ export const NodesSelectionTable: React.FC = () => {
       </StackItem>
       <StackItem>
         <HelperText>
-          <HelperTextItem variant="indeterminate" icon={<InfoIcon />}>
+          <HelperTextItem>
             {vm.sharedDisksCountMessage}
           </HelperTextItem>
         </HelperText>

--- a/console/src/features/storage-clusters/hooks/useNodesSelectionTableViewModel.ts
+++ b/console/src/features/storage-clusters/hooks/useNodesSelectionTableViewModel.ts
@@ -96,10 +96,10 @@ export const useNodesSelectionTableViewModel =
         case n === 1:
           return t("{{n}} node selected", { n });
         case n >= 2 && s === 1:
-          return t("{{n}} nodes selected with {{s}} shared disk", { n, s });
+          return t("{{n}} nodes were selected, sharing {{s}} disk between them", { n, s });
         default:
           // n >= 2 && s >= 2
-          return t("{{n}} nodes selected with {{s}} shared disks", { n, s });
+          return t("{{n}} nodes were selected, sharing {{s}} disks between them", { n, s });
       }
     }, [selectedNodes.length, sharedDisksCount, t]);
 


### PR DESCRIPTION
Addresses:
- OCPNAS-174

- Changed label from "Name" to "File system name" in FileSystemCreateForm.
- Updated LUN properties from id/name to path/wwn in relevant components.
- Modified deletion modal title and button text for better user understanding.
- Removed unnecessary empty state message in FileSystemsTableEmptyState.
- Enhanced node selection messages for improved clarity.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>

## Summary by Sourcery

Refactor LUN and filesystem UI to use clearer naming conventions and improve user-facing text

Enhancements:
- Rename LUN model properties from id/name to path/WWN across hooks and components
- Update file system creation form label to 'File system name' and adjust table columns to show Path and WWN
- Revise deletion modal title and button labels to 'Delete File system', 'Delete', and 'Close' for better clarity
- Remove redundant empty state message in the file systems table
- Enhance node selection instructions with minimum node count and updated shared disk messaging