### PR TITLE
Use stable-v1 for the channel name

### DIFF
--- a/certified-bundles/0.9.3/metadata/annotations.yaml
+++ b/certified-bundles/0.9.3/metadata/annotations.yaml
@@ -4,7 +4,7 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: openshift-fusion-access-operator
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: stable-v1
   operators.operatorframework.io.metrics.builder: operator-sdk-unknown
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change operators.operatorframework.io.bundle.channels.v1 annotation to stable-v1 in certified-bundles/0.9.3