### PR TITLE
fix: update kmm secret when token changes

### DIFF
--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -63,7 +63,7 @@ func CreateOrUpdateKMMResources(ctx context.Context, cl client.Client) error {
 		return fmt.Errorf("failed to get namespace in CreateOrUpdateKMMResources: %w", err)
 	}
 
-	KMMImageConfig, err := getKMMImageConfig(ctx, cl, ns)
+	KMMImageConfig, err := GetKMMImageConfig(ctx, cl, ns)
 	if err != nil {
 		return fmt.Errorf("failed to get KMMImageConfigmap in CreateOrUpdateKMMResources: %w", err)
 	}
@@ -220,7 +220,8 @@ type KMMImageConfig struct {
 	RegistrySecretName string
 }
 
-func getKMMImageConfig(ctx context.Context, cl client.Client, namespace string) (KMMImageConfig, error) {
+// Public function to get KMMImageConfig from ConfigMap held in var GetKMMImageConfig
+var GetKMMImageConfig = func(ctx context.Context, cl client.Client, namespace string) (KMMImageConfig, error) {
 	config := KMMImageConfig{
 		RegistryURL:        "image-registry.openshift-image-registry.svc:5000",
 		Repo:               fmt.Sprintf("%s/gpfs_compat_kmod", namespace),
@@ -234,7 +235,7 @@ func getKMMImageConfig(ctx context.Context, cl client.Client, namespace string) 
 			log.Log.Info(fmt.Sprintf("Configmap %s not found, using default values", KMMImageConfigMapName))
 			return config, nil
 		}
-		return config, fmt.Errorf("failed to get configmap %s in getKMMImageConfig: %w", KMMImageConfigMapName, err)
+		return config, fmt.Errorf("failed to get configmap %s in GetKMMImageConfig: %w", KMMImageConfigMapName, err)
 	}
 	data := cm.Data
 
@@ -274,7 +275,7 @@ func getMergedRegistrySecret(ctx context.Context, cl client.Client, namespace st
 			return nil, fmt.Errorf("failed to get secret %s in getMergedRegistrySecret: %w", kmmImageConfig.RegistrySecretName, err)
 		}
 	} else {
-		builderSecretName, err := getServiceAccountDockercfgSecretName(ctx, cl, namespace, "builder")
+		builderSecretName, err := GetServiceAccountDockercfgSecretName(ctx, cl, namespace, "builder")
 		if err != nil {
 			return nil, fmt.Errorf("error fetching dockercfg secret in getMergedRegistrySecret: %w", err)
 		}
@@ -365,8 +366,8 @@ COPY --from=builder /usr/lpp/mmfs/bin/lxtrace-${KERNEL_FULL_VERSION} /opt/lxtrac
 	}
 }
 
-// getServiceAccountDockercfgSecretName fetches the Docker config secret name for a given service account
-func getServiceAccountDockercfgSecretName(ctx context.Context, cl client.Client, namespace, serviceAccountName string) (string, error) {
+// GetServiceAccountDockercfgSecretName fetches the Docker config secret name for a given service account
+var GetServiceAccountDockercfgSecretName = func(ctx context.Context, cl client.Client, namespace, serviceAccountName string) (string, error) {
 	// Define the secret name pattern based on the service account name
 	secretPattern := fmt.Sprintf("^%s-dockercfg-.*$", serviceAccountName)
 


### PR DESCRIPTION
This address OCPNAS-170.

1. It watches the default secret's content change and recreation with new name OR
2. It also watches for content change in the secret mentioned in kmm-image-config 

<img width="1675" height="800" alt="image" src="https://github.com/user-attachments/assets/9cd42ac4-3682-4d6b-9810-c373a2a7f5f5" />

## Summary by Sourcery

Watch and reconcile FusionAccess when the registry secret or KMM image ConfigMap changes to ensure the KMM secret is updated on token or configuration updates

Bug Fixes:
- Ensure the KMM secret is updated when the registry token is rotated or the KMM image config changes

Enhancements:
- Add watches on registry secrets and the KMMImageConfigMap in FusionAccessReconciler to trigger reconciliations on changes
- Unify secret and configmap event handling under a single fusionAccessHandler
- Implement didTheRegistrySecretChange and didTheKmmConfigMapChange predicates to filter relevant events
- Introduce getCurrentRegistrySecretName helper to resolve registry secret names with ConfigMap override and fallback logic
- Expose GetKMMImageConfig and GetServiceAccountDockercfgSecretName as injectable variables for testability

Tests:
- Add unit tests for getCurrentRegistrySecretName covering override, fallback, and error scenarios