### PR TITLE
Move to golanci-lint v2.2.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.2.2
           args: --timeout 5m -v
 
           #--exclude SA5011

--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ $(LOCALBIN):
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.3
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
-GOLANGCI_LINT_VERSION ?= v2.1.6
+GOLANGCI_LINT_VERSION ?= v2.2.2
 # update for major version updates to YQ_VERSION!
 YQ_API_VERSION = v4
 YQ_VERSION = v4.45.4


### PR DESCRIPTION
## Summary by Sourcery

Bump golangci-lint to v2.2.2 in CI workflow and Makefile

Build:
- Bump GOLANGCI_LINT_VERSION in Makefile to v2.2.2

CI:
- Update golangci-lint GitHub action to v2.2.2