### PR TITLE
fix env var

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
         # Inject dependency images as env variables to instruct the operator-sdk to
         # add them as relatedImages in the CSV. This information is required for disconnected environments.
         # More info: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/operators/index#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
-          - name: RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER
+          - name: RELATED_IMAGE_OPENSHIFT_STORAGE_SCALE_OPERATOR_DEVICEFINDER
             value: ${DEVICEFINDER_IMAGE}
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/common/names.go
+++ b/internal/common/names.go
@@ -12,8 +12,8 @@ const (
 	// OwnerNameLabel references the owning object
 	OwnerNameLabel = "fusion.storage.openshift.io/owner-name"
 
-	// DeviceFinderImageEnv is used by the operator to read the RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER from the environment
-	DeviceFinderImageEnv = "RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER"
+	// DeviceFinderImageEnv is used by the operator to read the RELATED_IMAGE_OPENSHIFT_STORAGE_SCALE_OPERATOR_DEVICEFINDER from the environment
+	DeviceFinderImageEnv = "RELATED_IMAGE_OPENSHIFT_STORAGE_SCALE_OPERATOR_DEVICEFINDER"
 	// KubeRBACProxyImageEnv is used by the operator to read the KUBE_RBAC_PROXY_IMAGE from the environment
 	KubeRBACProxyImageEnv = "KUBE_RBAC_PROXY_IMAGE"
 


### PR DESCRIPTION
- **Fix env variable to contain only valid characters.**

## Summary by Sourcery

Fix environment variable naming for the DeviceFinder image by replacing invalid characters (hyphens) with underscores in both the operator code and the manager manifest

Bug Fixes:
- Correct DeviceFinderImageEnv value to RELATED_IMAGE_OPENSHIFT_STORAGE_SCALE_OPERATOR_DEVICEFINDER
- Update manager.yaml to reference the new underscore-based env var name