### PR TITLE
Add functionality to check internal registry storage backend

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,7 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 
 	consolev1 "github.com/openshift/api/console/v1"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	lvdcontroller "github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/controller/localvolumediscovery"
@@ -63,6 +64,8 @@ func init() {
 	utilruntime.Must(machineconfigv1.AddToScheme(scheme))
 
 	utilruntime.Must(consolev1.AddToScheme(scheme))
+
+	utilruntime.Must(imageregistryv1.AddToScheme(scheme))
 
 	utilruntime.Must(operatorv1.AddToScheme(scheme))
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -274,6 +274,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - imageregistry.operator.openshift.io
+  resources:
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kmm.sigs.x-k8s.io
   resources:
   - modules

--- a/internal/controller/imageregistry/imageregistry.go
+++ b/internal/controller/imageregistry/imageregistry.go
@@ -1,0 +1,65 @@
+package imageregistry
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/controller/kernelmodule"
+)
+
+// CheckImageRegistryStorage validates that the OpenShift image registry is not using emptyDir storage
+func CheckImageRegistryStorage(ctx context.Context, c client.Client) error {
+	// Get the cluster-scoped image registry configuration
+	imageRegistryConfig := &imageregistryv1.Config{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "cluster"}, imageRegistryConfig); err != nil {
+		if kerrors.IsNotFound(err) {
+			log.Log.Info("Image registry config not found, assuming default configuration")
+			return nil
+		}
+		return fmt.Errorf("failed to get image registry configuration: %w", err)
+	}
+
+	// Check if emptyDir storage is configured
+	if imageRegistryConfig.Spec.Storage.EmptyDir != nil {
+		return fmt.Errorf("image registry is configured with emptyDir storage which is not supported for kernel module builds. " +
+			"EmptyDir storage is ephemeral and unsuitable for production use. " +
+			"Please configure the image registry with persistent storage (PVC, S3, GCS, Azure, etc.). " +
+			"For more information, see: https://docs.openshift.com/container-platform/latest/registry/configuring_registry_storage/configuring-registry-storage-aws-user-infrastructure.html")
+	}
+
+	// Also check the status to see what storage is actually being used
+	if imageRegistryConfig.Status.Storage.EmptyDir != nil {
+		return fmt.Errorf("image registry is currently using emptyDir storage which is not supported for kernel module builds. " +
+			"EmptyDir storage is ephemeral and unsuitable for production use. " +
+			"Please configure the image registry with persistent storage (PVC, S3, GCS, Azure, etc.). " +
+			"For more information, see: https://docs.openshift.com/container-platform/latest/registry/configuring_registry_storage/configuring-registry-storage-aws-user-infrastructure.html")
+	}
+
+	log.Log.Info("Image registry storage validation passed", "managementState", imageRegistryConfig.Status.Storage.ManagementState)
+	return nil
+}
+
+// IsUsingInternalImageRegistry checks if the current KMM configuration is using the internal image registry
+func IsUsingInternalImageRegistry(ctx context.Context, c client.Client, ns string) (bool, error) {
+	kmmConfig, err := kernelmodule.GetKMMImageConfig(ctx, c, ns)
+	if err != nil {
+		return false, fmt.Errorf("failed to get KMM image config: %w", err)
+	}
+
+	// Check if the registry URL points to the internal image registry
+	internalRegistryURLs := []string{
+		"image-registry.openshift-image-registry.svc:5000",
+		"image-registry.openshift-image-registry.svc.cluster.local:5000",
+		"docker-registry.default.svc:5000",
+		"docker-registry.default.svc.cluster.local:5000",
+	}
+
+	return slices.Contains(internalRegistryURLs, kmmConfig.RegistryURL), nil
+}

--- a/internal/controller/imageregistry/imageregistry_test.go
+++ b/internal/controller/imageregistry/imageregistry_test.go
@@ -1,0 +1,309 @@
+package imageregistry
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/controller/kernelmodule"
+)
+
+var _ = Describe("Image Registry Validation", func() {
+	const testNamespace = "test-namespace"
+
+	Describe("CheckImageRegistryStorage", func() {
+		var (
+			scheme *runtime.Scheme
+			ctx    context.Context
+		)
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			_ = imageregistryv1.AddToScheme(scheme)
+			ctx = context.Background()
+		})
+
+		Context("when image registry config is not found", func() {
+			It("should return no error", func() {
+				client := fake.NewClientBuilder().WithScheme(scheme).Build()
+				err := CheckImageRegistryStorage(ctx, client)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when image registry spec has emptyDir storage", func() {
+			It("should return an error", func() {
+				registryConfig := &imageregistryv1.Config{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: imageregistryv1.ImageRegistrySpec{
+						Storage: imageregistryv1.ImageRegistryConfigStorage{
+							EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
+						},
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(registryConfig).Build()
+				err := CheckImageRegistryStorage(ctx, client)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("image registry is configured with emptyDir storage"))
+			})
+		})
+
+		Context("when image registry status has emptyDir storage", func() {
+			It("should return an error", func() {
+				registryConfig := &imageregistryv1.Config{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: imageregistryv1.ImageRegistrySpec{
+						Storage: imageregistryv1.ImageRegistryConfigStorage{},
+					},
+					Status: imageregistryv1.ImageRegistryStatus{
+						Storage: imageregistryv1.ImageRegistryConfigStorage{
+							EmptyDir: &imageregistryv1.ImageRegistryConfigStorageEmptyDir{},
+						},
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(registryConfig).Build()
+				err := CheckImageRegistryStorage(ctx, client)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("image registry is currently using emptyDir storage"))
+			})
+		})
+
+		Context("when image registry uses PVC storage", func() {
+			It("should return no error", func() {
+				registryConfig := &imageregistryv1.Config{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: imageregistryv1.ImageRegistrySpec{
+						Storage: imageregistryv1.ImageRegistryConfigStorage{
+							PVC: &imageregistryv1.ImageRegistryConfigStoragePVC{
+								Claim: "image-registry-storage",
+							},
+						},
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(registryConfig).Build()
+				err := CheckImageRegistryStorage(ctx, client)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when image registry uses S3 storage", func() {
+			It("should return no error", func() {
+				registryConfig := &imageregistryv1.Config{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: imageregistryv1.ImageRegistrySpec{
+						Storage: imageregistryv1.ImageRegistryConfigStorage{
+							S3: &imageregistryv1.ImageRegistryConfigStorageS3{
+								Bucket: "my-registry-bucket",
+								Region: "us-east-1",
+							},
+						},
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(registryConfig).Build()
+				err := CheckImageRegistryStorage(ctx, client)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when image registry has no storage configuration", func() {
+			It("should return no error", func() {
+				registryConfig := &imageregistryv1.Config{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: imageregistryv1.ImageRegistrySpec{
+						Storage: imageregistryv1.ImageRegistryConfigStorage{},
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(registryConfig).Build()
+				err := CheckImageRegistryStorage(ctx, client)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when client.Get returns an error", func() {
+			It("should return the error", func() {
+				// Create a fake client that returns an error for Get operations
+				client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+				// Simulate a generic API error
+				registryConfig := &imageregistryv1.Config{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+				}
+
+				// Force an error by trying to get from wrong namespace
+				err := client.Get(ctx, types.NamespacedName{Name: "nonexistent"}, registryConfig)
+				Expect(err).To(HaveOccurred())
+				Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("IsUsingInternalImageRegistry", func() {
+		var (
+			scheme *runtime.Scheme
+			ctx    context.Context
+		)
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			ctx = context.Background()
+		})
+
+		Context("when KMM config uses internal registry URL", func() {
+			It("should return true for image-registry.openshift-image-registry.svc:5000", func() {
+				kmmConfig := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kernelmodule.KMMImageConfigMapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						kernelmodule.KMMImageConfigKeyRegistryURL: "image-registry.openshift-image-registry.svc:5000",
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kmmConfig).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return true for image-registry.openshift-image-registry.svc.cluster.local:5000", func() {
+				kmmConfig := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kernelmodule.KMMImageConfigMapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						kernelmodule.KMMImageConfigKeyRegistryURL: "image-registry.openshift-image-registry.svc.cluster.local:5000",
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kmmConfig).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return true for docker-registry.default.svc:5000", func() {
+				kmmConfig := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kernelmodule.KMMImageConfigMapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						kernelmodule.KMMImageConfigKeyRegistryURL: "docker-registry.default.svc:5000",
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kmmConfig).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return true for docker-registry.default.svc.cluster.local:5000", func() {
+				kmmConfig := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kernelmodule.KMMImageConfigMapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						kernelmodule.KMMImageConfigKeyRegistryURL: "docker-registry.default.svc.cluster.local:5000",
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kmmConfig).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when KMM config uses external registry URL", func() {
+			It("should return false for external registry", func() {
+				kmmConfig := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kernelmodule.KMMImageConfigMapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						kernelmodule.KMMImageConfigKeyRegistryURL: "quay.io",
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kmmConfig).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return false for docker hub", func() {
+				kmmConfig := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kernelmodule.KMMImageConfigMapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						kernelmodule.KMMImageConfigKeyRegistryURL: "docker.io",
+					},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kmmConfig).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return false for empty registry URL", func() {
+				kmmConfig := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kernelmodule.KMMImageConfigMapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{},
+				}
+
+				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kmmConfig).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when KMM config does not exist", func() {
+			It("should return an error", func() {
+				client := fake.NewClientBuilder().WithScheme(scheme).Build()
+				result, err := IsUsingInternalImageRegistry(ctx, client, testNamespace)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeFalse())
+				Expect(err.Error()).To(ContainSubstring("failed to get KMM image config"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
If the internal registry is using emptydir as a backend, it makes the
kernel module loading and building unstable. We can ensure that a non
ephemeral backend is used for internal registry.

## Summary by Sourcery

Ensure that when using the internal OpenShift image registry, it is backed by a non-ephemeral storage backend by detecting registry usage, validating against emptyDir, and reflecting the result in the FusionAccess resource status.

New Features:
- Add functions to detect internal image registry usage and to validate that the registry storage is not using emptyDir

Enhancements:
- Integrate image registry storage validation into FusionAccess reconciliation and update status conditions accordingly
- Export KMM image config getter function and register the imageregistry API in the operator scheme

Tests:
- Add unit tests for image registry storage checks and internal registry detection