### PR TITLE
Use the correct version of IBM Storage Scale.

### DIFF
--- a/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operatorframework.io/initialization-resource: '{"apiVersion":"fusion.storage.openshift.io/v1alpha1","kind":"FusionAccess","metadata":{"name":"fusionaccess-object"},"spec":{"storageScaleVersion":"v5.2.3.0.1"}}'
+    operatorframework.io/initialization-resource: '{"apiVersion":"fusion.storage.openshift.io/v1alpha1","kind":"FusionAccess","metadata":{"name":"fusionaccess-object"},"spec":{"storageScaleVersion":"v5.2.3.1"}}'
     operatorframework.io/suggested-namespace: ibm-fusion-access
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.openshift.io/valid-subscription: '["Openshift Container Platform","OpenShift

--- a/config/samples/fusion_v1alpha1_fusionaccess.yaml
+++ b/config/samples/fusion_v1alpha1_fusionaccess.yaml
@@ -3,4 +3,4 @@ kind: FusionAccess
 metadata:
   name: fusionaccess-object
 spec:
-  storageScaleVersion: "v5.2.3.0.1"
+  storageScaleVersion: "v5.2.3.1"

--- a/console/src/shared/types/fusion-access/FusionAccess.ts
+++ b/console/src/shared/types/fusion-access/FusionAccess.ts
@@ -24,7 +24,7 @@ interface FusionAccessSpec {
   /**
    * Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
    */
-  storageScaleVersion?: "v5.2.3.0.1";
+  storageScaleVersion?: "v5.2.3.1";
 }
 
 /**


### PR DESCRIPTION
Fixes OCPNAS-178.

## Summary by Sourcery

Update IBM Storage Scale version to v5.2.3.1 across operator manifests, sample configuration, and type definitions.

Bug Fixes:
- Corrects the storageScaleVersion from v5.2.3.0.1 to v5.2.3.1 in the CSV initialization resource
- Updates the sample FusionAccess manifest to use the new storageScaleVersion
- Adjusts the TypeScript FusionAccess type to reflect the updated storageScaleVersion