### PR TITLE
Fix URL links to proper doc site

### DIFF
--- a/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
@@ -89,7 +89,7 @@ spec:
   - name: Fusion Access for SAN
     url: https://access.ibmfusion.eu/
   - name: Documentation
-    url: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/fusion_access_san/index
+    url: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/virtualization-with-ibm-fusion-access-for-san
   maintainers:
   - email: michele@redhat.com
     name: mbaldessari

--- a/console/src/constants.ts
+++ b/console/src/constants.ts
@@ -2,7 +2,7 @@ import { t } from "@/shared/hooks/useFusionAccessTranslations";
 
 // This link will need to be updated in-between versions 
 export const LEARN_MORE_LINK =
-  "https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/fusion_access_san/index";
+  "https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/virtualization-with-ibm-fusion-access-for-san";
 export const MINIMUM_AMOUNT_OF_NODES = 3;
 export const MINIMUM_AMOUNT_OF_NODES_LITERAL = t("three");
 export const MINIMUM_AMOUNT_OF_SHARED_DISKS = 1;


### PR DESCRIPTION
## Summary by Sourcery

Update documentation URLs in the operator CSV and console constants to point to the correct Fusion Access for SAN documentation path.

Bug Fixes:
- Fix the Documentation URL in openshift-fusion-access-operator.clusterserviceversion.yaml to the proper doc site path
- Update the LEARN_MORE_LINK constant in console/src/constants.ts to the corrected documentation URL