### PR TITLE
Drop confusing link for cnsa version

### DIFF
--- a/api/v1alpha1/fusionaccess_types.go
+++ b/api/v1alpha1/fusionaccess_types.go
@@ -30,7 +30,7 @@ type FusionAccessSpec struct {
 	// NOTE(bandini): If you change anything in the following three lines you need to update
 	// ./scripts/update-cnsa-versions-metadata.sh
 
-	// Version of IBMs installation manifests found at https://github.com/IBM/ibm-spectrum-scale-container-native
+	// Version of IBM Fusion installation manifest
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="IBM Storage Scale Version",order=2,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:v5.2.3.1"}
 	StorageScaleVersion StorageScaleVersions `json:"storageScaleVersion,omitempty"`
 


### PR DESCRIPTION
## Summary by Sourcery

Remove outdated GitHub link from the StorageScaleVersion field comment and simplify its description to reference the IBM Fusion installation manifest.

Documentation:
- Drop confusing external link from the StorageScaleVersion comment
- Update comment to describe the IBM Fusion installation manifest version