### PR TITLE
Use the v1 konflux application in our release scripts by default

### DIFF
--- a/scripts/konflux-release.sh
+++ b/scripts/konflux-release.sh
@@ -37,7 +37,7 @@ if ! oc project "${PROJ}" &> /dev/null; then
   exit 1
 fi
 
-applicationName=operator-0-1
+applicationName=${KONFLUX_APPLICATION:-"operator-1-0"}
 releaseVersion=$(echo $applicationName | sed 's/operator//g')
 operator_bundle=$(oc get components -ojsonpath='{range .items[?(@.spec.application=="'$applicationName'")]}{.metadata.name}{"\n"}{end}' | grep bundle)
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Parameterize the konflux application name via the KONFLUX_APPLICATION environment variable and update the default to operator-1-0