### PR TITLE
refactor: standardize learn more links across empty state components

### DIFF
--- a/console/src/features/file-systems/components/FileSystemsTableEmptyState.tsx
+++ b/console/src/features/file-systems/components/FileSystemsTableEmptyState.tsx
@@ -8,6 +8,7 @@ import { ExternalLinkAltIcon, FolderIcon } from "@patternfly/react-icons";
 import { useFusionAccessTranslations } from "@/shared/hooks/useFusionAccessTranslations";
 import { useRedirectHandler } from "@/shared/hooks/useRedirectHandler";
 import { FileSystemsCreateButton } from "./FileSystemsCreateButton";
+import { LEARN_MORE_LINK } from "@/constants";
 
 export const FileSystemsTableEmptyState: React.FC = () => {
   const { t } = useFusionAccessTranslations();
@@ -32,7 +33,7 @@ export const FileSystemsTableEmptyState: React.FC = () => {
             variant="link"
             target="_blank"
             rel="noopener noreferrer"
-            href="#"
+            href={LEARN_MORE_LINK}
           >
             {t("Learn more about Fusion Access for SAN storage clusters")}{" "}
             <ExternalLinkAltIcon />

--- a/console/src/features/storage-clusters/components/StorageClusterEmptyState.tsx
+++ b/console/src/features/storage-clusters/components/StorageClusterEmptyState.tsx
@@ -12,16 +12,16 @@ import {
 } from "@patternfly/react-icons";
 import { useFusionAccessTranslations } from "@/shared/hooks/useFusionAccessTranslations";
 import { StorageClustersCreateButton } from "@/features/storage-clusters/components/StorageClustersCreateButton";
+import { LEARN_MORE_LINK } from "@/constants";
 
 interface StorageClusterEmptyStateProps {
   onCreateStorageCluster: React.MouseEventHandler<HTMLButtonElement>;
-  learnMoreHref?: string;
 }
 
 export const StorageClusterEmptyState: React.FC<
   StorageClusterEmptyStateProps
 > = (props) => {
-  const { onCreateStorageCluster, learnMoreHref = "" } = props;
+  const { onCreateStorageCluster } = props;
   const { t } = useFusionAccessTranslations();
 
   return (
@@ -45,7 +45,7 @@ export const StorageClusterEmptyState: React.FC<
             variant="link"
             target="_blank"
             rel="noopener noreferrer"
-            href={learnMoreHref}
+            href={LEARN_MORE_LINK}
           >
             {t("Learn more about Fusion Access for SAN storage clusters")}{" "}
             <ExternalLinkAltIcon />

--- a/console/src/features/storage-clusters/pages/StorageClusterHomePage.tsx
+++ b/console/src/features/storage-clusters/pages/StorageClusterHomePage.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/shared/hooks/useRedirectHandler";
 import { DefaultErrorFallback } from "@/shared/components/DefaultErrorFallback";
 import { DefaultLoadingFallback } from "@/shared/components/DefaultLoadingFallback";
-import { LEARN_MORE_LINK } from "@/constants";
 
 const StorageClusterHomePage: React.FC = () => {
   return (
@@ -54,7 +53,6 @@ const ConnectedStorageClusterHomePage: React.FC = () => {
         {(storageClusters.data ?? []).length === 0 ? (
           <StorageClusterEmptyState
             onCreateStorageCluster={redirectToCreateStorageCluster}
-            learnMoreHref={LEARN_MORE_LINK}
           />
         ) : (
           <Redirect to={UrlPaths.FileSystemsHome} />


### PR DESCRIPTION
- Replace hardcoded placeholder href with LEARN_MORE_LINK constant in FileSystemsTableEmptyState
- Remove learnMoreHref prop from StorageClusterEmptyState and use LEARN_MORE_LINK constant
- Clean up unused prop passing in StorageClusterHomePage

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>

## Summary by Sourcery

Standardize “Learn more” links across empty state components by using the shared LEARN_MORE_LINK constant and remove obsolete props and imports.

Enhancements:
- Use LEARN_MORE_LINK constant instead of hardcoded or prop-driven URLs in FileSystemsTableEmptyState and StorageClusterEmptyState
- Remove learnMoreHref prop and its passing/import in StorageClusterEmptyState and StorageClusterHomePage