### PR TITLE
fix: Remove hardcoded docker usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
1 liner to clean up a hard coded usage of docker instead of `$CONTAINER_TOOL`

## Summary by Sourcery

Bug Fixes:
- Fix hardcoded container tool in catalog-build by using $(CONTAINER_TOOL) instead of 'docker'