### PR TITLE
Stop using gopkg.in/yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,13 +15,13 @@ require (
 	github.com/rh-ecosystem-edge/kernel-module-management v0.0.0-20250710091453-478659262549
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
 	k8s.io/component-helpers v0.32.3
 	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.20.4
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -78,6 +78,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.32.2 // indirect
 	k8s.io/kube-aggregator v0.32.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250610211856-8b98d1ed966a // indirect
@@ -86,7 +87,6 @@ require (
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace (

--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/kubeutils"
 	"github.com/openshift-storage-scale/openshift-fusion-access-operator/internal/utils"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Git repo has been archived [1] and we were using the sig.k8s.io yaml one
already anyways

[1] https://github.com/go-yaml/yaml/tree/v3.0.1

## Summary by Sourcery

Replace usage of the archived gopkg.in/yaml.v3 library with sigs.k8s.io/yaml and adjust YAML parsing accordingly

Enhancements:
- Switch imports from gopkg.in/yaml.v3 to sigs.k8s.io/yaml throughout the codebase
- Refactor multi-document YAML parsing in ParseYAMLAndExtractTestImage to use string splitting and yaml.Unmarshal
- Update go.mod to remove the direct gopkg.in/yaml.v3 dependency and add sigs.k8s.io/yaml v1.4.0

Build:
- Adjust go.mod to reflect the new YAML dependency setup