### PR TITLE
Stop using the imagehash as selector for the kmm module

### DIFF
--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -138,16 +138,10 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 		ibmImageHash = ibmImageHash[:maxHashLength]
 	}
 
-	ibmImageHashLabel := getIBMCoreImageHashForLabel(ibmScaleImage)
-	if ibmImageHashLabel != "" {
-		selector = map[string]string{
-			"kubernetes.io/arch":                  "amd64",
-			"scale.spectrum.ibm.com/image-digest": ibmImageHashLabel,
-		}
-	} else {
-		selector = map[string]string{
-			"kubernetes.io/arch": "amd64",
-		}
+	// TODO: Fetch the selector from the cluster CR
+	selector = map[string]string{
+		"kubernetes.io/arch":                     "amd64",
+		"scale.spectrum.ibm.com/daemon-selector": "",
 	}
 
 	// See https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/specialized_hardware_and_driver_enablement/


### PR DESCRIPTION
At the time we introduced this selector in order to add some guarantees
that a new gpfs module would only be loaded on nodes which already have
a new core pod.

The problem with this is that if a pod restarts it will briefly remove
that image-digest label, which will trigger kmm to try and rmmod the
kernel module. This will fail of course, because the filesystem is still
mounted.

Let's just use the daemon-selector which is a label that does not go
away when core pods are restarted.

The risk of getting new gpfs kernel modules on nodes which have old CNSA
is next to zero because kmm will be unable to rmmod the kernel modules
anyways because the core pods are running.

Co-Authored-By: Akos Eros <aeros@redhat.com>

## Summary by Sourcery

Replace the transient image-digest selector for KMM modules with a stable daemon-selector label to prevent unintended module unloads on pod restarts.

Enhancements:
- Change kernel module selector to use the persistent "scale.spectrum.ibm.com/daemon-selector" label instead of the image-digest label
- Always select only amd64 architecture nodes for the gpfs module