### PR TITLE
OCPNAS-216 | fix: Use PodDisruptionBudget to fix race condition in KMM during upgrades

### DIFF
--- a/internal/controller/fusionaccess_controller.go
+++ b/internal/controller/fusionaccess_controller.go
@@ -27,9 +27,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
+	policyv1 "k8s.io/api/policy/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -319,6 +321,12 @@ func (r *FusionAccessReconciler) Reconcile(
 	// }
 	ns, err := utils.GetDeploymentNamespace()
 	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.createPodDisruptionBudget(ctx, fusionaccess)
+	if err != nil {
+		log.Log.Error(err, "Failed to create or update PodDisruptionBudget")
 		return ctrl.Result{}, err
 	}
 
@@ -695,4 +703,34 @@ func didTheKmmConfigMapChange() builder.WatchesOption {
 		},
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	})
+}
+
+func (r *FusionAccessReconciler) createPodDisruptionBudget(ctx context.Context, fusionaccess *fusionv1alpha1.FusionAccess) error {
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "kmm-pdb",
+			Namespace: fusionaccess.Namespace,
+		},
+	}
+
+	_, err := ctrl.CreateOrUpdate(ctx, r.Client, pdb, func() error {
+		pdb.Spec = policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 1,
+			},
+			Selector: &v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "openshift.io/build.name",
+						Operator: v1.LabelSelectorOpExists,
+					},
+				},
+			},
+		}
+		// TODO: If we decide to include the PDB in the uninstall process, include the controller reference below
+		// return ctrl.SetControllerReference(fusionaccess, pdb, r.Scheme)
+		return nil
+	})
+	return err
 }


### PR DESCRIPTION
Add a Pod Disruption Budget object to the fusion access reconciler loop in order to ensure that when running fusion access operators, it does not drain the node running the KMM module's updates before the module has complete its function.

## Summary by Sourcery

Add a PodDisruptionBudget in the FusionAccess reconciler to protect KMM pods from eviction during upgrades and avoid race conditions

Bug Fixes:
- Fix OCPNAS-216 race condition by preventing KMM module pods from being evicted during upgrades

Enhancements:
- Introduce a PodDisruptionBudget with minAvailable=1 and a selector for KMM pods
- Set the FusionAccess resource as the controller owner of the PodDisruptionBudget