### PR TITLE
OCPNAS-214 | fix: Change label used to reconcile KMM Module to remove race condition on pod restart

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,7 +10,12 @@ GIT_VERSION=$(git describe --always --tags || true)
 VERSION=${CI_UPSTREAM_VERSION:-${GIT_VERSION}}
 GIT_COMMIT=$(git rev-list -1 HEAD || true)
 COMMIT=${CI_UPSTREAM_COMMIT:-${GIT_COMMIT}}
-BUILD_DATE=$(date --utc -Iseconds)
+if date --utc -Iseconds >/dev/null 2>&1; then
+    BUILD_DATE=$(date --utc -Iseconds)
+else
+    # macOS fallback: emulate --utc -Iseconds
+    BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+fi
 
 LDFLAGS="-s -w "
 REPO="github.com/openshift-storage-scale/openshift-fusion-access-operator"

--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -95,12 +96,47 @@ func CreateOrUpdateKMMResources(ctx context.Context, cl client.Client) error {
 	}
 	signModules := doSigningSecretsExist(ctx, cl, ns)
 
-	kernelModule := NewKMMModule(ns, ibmScaleImage, signModules, &KMMImageConfig)
+	spectrumCluster, err := getCluster(ctx, cl)
+	if err != nil {
+		return fmt.Errorf("failed to get spectrumCluster in CreateOrUpdateKMMResources: %w", err)
+	}
+
+	labelSelector := getLabelSelector(spectrumCluster)
+
+	kernelModule := NewKMMModule(ns, ibmScaleImage, signModules, &KMMImageConfig, labelSelector)
 	if err := kubeutils.CreateOrUpdateResource(ctx, cl, kernelModule, mutateKMMModule); err != nil {
 		return fmt.Errorf("failed to update kernelModule in CreateOrUpdateKMMResources: %w", err)
 	}
 
 	return nil
+}
+
+func getCluster(ctx context.Context, cl client.Client) (*unstructured.Unstructured, error) {
+	spectrumCluster := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "scale.spectrum.ibm.com/v1beta1",
+			"kind":       "Cluster",
+			"metadata": map[string]any{
+				"name":      "ibm-spectrum-scale",
+				"namespace": "ibm-spectrum-scale",
+			},
+		},
+	}
+
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: "ibm-spectrum-scale", Name: "ibm-spectrum-scale"}, spectrumCluster); err != nil {
+		return nil, fmt.Errorf("failed to get spectrumCluster, please make sure your storage cluster has been created: %w", err)
+	}
+
+	return spectrumCluster, nil
+}
+
+func getLabelSelector(spectrumCluster *unstructured.Unstructured) map[string]string {
+	nodeSelectorRaw := spectrumCluster.Object["spec"].(map[string]any)["daemon"].(map[string]any)["nodeSelector"].(map[string]any)
+	labelSelector := make(map[string]string)
+	for k, v := range nodeSelectorRaw {
+		labelSelector[k] = v.(string)
+	}
+	return labelSelector
 }
 
 func doSigningSecretsExist(ctx context.Context, cl client.Client, namespace string) bool {
@@ -126,9 +162,8 @@ func mutateKMMModule(existing, desired *kmmv1beta1.Module) error {
 	return nil
 }
 
-func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KMMImageConfig) *kmmv1beta1.Module {
+func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KMMImageConfig, labelSelector map[string]string) *kmmv1beta1.Module {
 	var signing *kmmv1beta1.Sign
-	var selector map[string]string
 
 	ibmImageHash := getIBMCoreImageHash(ibmScaleImage)
 
@@ -136,18 +171,6 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 	const maxHashLength = 32
 	if len(ibmImageHash) > maxHashLength {
 		ibmImageHash = ibmImageHash[:maxHashLength]
-	}
-
-	ibmImageHashLabel := getIBMCoreImageHashForLabel(ibmScaleImage)
-	if ibmImageHashLabel != "" {
-		selector = map[string]string{
-			"kubernetes.io/arch":                  "amd64",
-			"scale.spectrum.ibm.com/image-digest": ibmImageHashLabel,
-		}
-	} else {
-		selector = map[string]string{
-			"kubernetes.io/arch": "amd64",
-		}
 	}
 
 	// See https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/specialized_hardware_and_driver_enablement/
@@ -217,7 +240,7 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 			ImageRepoSecret: func() *corev1.LocalObjectReference {
 				return &corev1.LocalObjectReference{Name: KMMRegistryPushPullSecretName}
 			}(),
-			Selector: selector,
+			Selector: labelSelector,
 		},
 	}
 }

--- a/internal/controller/kernelmodule/kernelmodule_test.go
+++ b/internal/controller/kernelmodule/kernelmodule_test.go
@@ -9,6 +9,7 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var _ = Describe("ExtractImageVersion", func() {
@@ -316,6 +317,46 @@ var _ = Describe("mutateKMMModule", func() {
 			Expect(existing.Spec.ModuleLoader.ServiceAccountName).To(Equal("new-service-account"))
 			Expect(existing.Spec.Selector).To(HaveKeyWithValue("env", "test"))
 			Expect(existing.Spec.ImageRepoSecret.Name).To(Equal("new-secret"))
+		})
+	})
+})
+
+var _ = Describe("getLabelSelector", func() {
+	var spectrumCluster *unstructured.Unstructured
+
+	Context("when spectrum cluster has valid nodeSelector", func() {
+		BeforeEach(func() {
+			spectrumCluster = &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "scale.spectrum.ibm.com/v1beta1",
+					"kind":       "Cluster",
+					"spec": map[string]any{
+						"daemon": map[string]any{
+							"nodeSelector": map[string]any{
+								"scale.spectrum.ibm.com/daemon-selector": "",
+								"kubernetes.io/arch":                     "amd64",
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should return the correct label selector", func() {
+			result := getLabelSelector(spectrumCluster)
+
+			Expect(result).To(HaveLen(2))
+			Expect(result).To(HaveKeyWithValue("scale.spectrum.ibm.com/daemon-selector", ""))
+			Expect(result).To(HaveKeyWithValue("kubernetes.io/arch", "amd64"))
+		})
+
+		It("should return a map of string to string", func() {
+			result := getLabelSelector(spectrumCluster)
+
+			for k, v := range result {
+				Expect(k).To(BeAssignableToTypeOf(""))
+				Expect(v).To(BeAssignableToTypeOf(""))
+			}
 		})
 	})
 })


### PR DESCRIPTION
OCPNAS-214 describes a race condition in which the restart of a core pod removes the labels used in the KMM reconciliation process. We are changing the KMM module to instead use a different label given by the cluster custom resource in order to ensure that there are no chances for this label to disappear and cause KMM to unnecessarily delete itself.

Also, quick fix to a date issue causing local build failures on hipster machines

## Summary by Sourcery

Use labels from the ibm-spectrum-scale custom resource instead of transient selectors for KMM module reconciliation to prevent race conditions on pod restart

Bug Fixes:
- Fix race condition where restarting core pods removed reconciliation labels and caused KMM to delete itself

Enhancements:
- Fetch labels from the ibm-spectrum-scale unstructured custom resource and pass them into NewKMMModule
- Update NewKMMModule signature to accept an external label selector and remove internal image-digest-based selector logic