### PR TITLE
Refactor: Comment out actions column and kebab menu actions in FileSystemsTableRow

### DIFF
--- a/console/src/features/file-systems/components/FileSystemsTableRow.tsx
+++ b/console/src/features/file-systems/components/FileSystemsTableRow.tsx
@@ -29,17 +29,18 @@ export const FileSystemsTabTableRow: React.FC<FileSystemsTabTableRowProps> = (
 
   const { t } = useFusionAccessTranslations();
 
-  const kebabMenuActions = useMemo<KebabMenuProps["items"]>(
-    () => [
-      {
-        key: "delete",
-        onClick: handleDelete(fileSystem),
-        description: vm.isInUse ? <div>{t("Filesystem is in use")}</div> : null,
-        children: t("Delete"),
-      },
-    ],
-    [fileSystem, handleDelete, t, vm.isInUse]
-  );
+  // TODO: Add actions column when we have actions to show (see conversation in https://issues.redhat.com/browse/OCPNAS-217)
+  // const kebabMenuActions = useMemo<KebabMenuProps["items"]>(
+  //   () => [
+  //     {
+  //       key: "delete",
+  //       onClick: handleDelete(fileSystem),
+  //       description: vm.isInUse ? <div>{t("Filesystem is in use")}</div> : null,
+  //       children: t("Delete"),
+  //     },
+  //   ],
+  //   [fileSystem, handleDelete, t, vm.isInUse]
+  // );
 
   return (
     <>
@@ -95,7 +96,7 @@ export const FileSystemsTabTableRow: React.FC<FileSystemsTabTableRowProps> = (
         />
       </TableData>
 
-      <TableData
+      {/* <TableData
         activeColumnIDs={activeColumnIDs}
         id={columns[5].id}
         className={columns[5].props.className}
@@ -108,7 +109,7 @@ export const FileSystemsTabTableRow: React.FC<FileSystemsTabTableRowProps> = (
             items={kebabMenuActions}
           />
         )}
-      </TableData>
+      </TableData> */}
     </>
   );
 };

--- a/console/src/features/file-systems/hooks/useFileSystemsTableViewModel.ts
+++ b/console/src/features/file-systems/hooks/useFileSystemsTableViewModel.ts
@@ -36,11 +36,12 @@ export const useFileSystemsTableViewModel = () => {
         title: t("Link to file system dashboard"),
         props: { className: "pf-v6-u-w-10" },
       },
-      {
-        id: "actions",
-        title: "",
-        props: { className: "pf-v6-c-table__action" },
-      },
+      // TODO: Add actions column when we have actions to show (see conversation in https://issues.redhat.com/browse/OCPNAS-217)
+      // {
+      //   id: "actions",
+      //   title: "",
+      //   props: { className: "pf-v6-c-table__action" },
+      // },
     ],
     [t]
   );


### PR DESCRIPTION
Temporarily disable the actions column and related kebab menu actions in the FileSystemsTableRow component. This change is made in anticipation of future updates when actions will be implemented, as noted in the associated issue OCPNAS-217.|