### PR TITLE
add codeowners file to ensure we are reviewers on PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global code ownership
+# All files in the repository are owned by the Firefly team
+* @openshift-storage-scale/Firefly


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add .github/CODEOWNERS file to ensure designated reviewers are auto-requested