### PR TITLE
OCPNAS 229

### DIFF
--- a/console/src/constants.ts
+++ b/console/src/constants.ts
@@ -10,7 +10,8 @@ export const MINIMUM_AMOUNT_OF_SHARED_DISKS_LITERAL = t("one");
 export const MINIMUM_AMOUNT_OF_MEMORY_GIB = 20;
 export const MINIMUM_AMOUNT_OF_MEMORY_GIB_LITERAL = "20 GiB";
 export const VALUE_NOT_AVAILABLE = "--";
-export const STORAGE_ROLE_LABEL = "scale.spectrum.ibm.com/role=storage";
+// This has to match the values we use in operator code (KMMNodeSelectorKey, KMMNodeSelectorValue)
+export const STORAGE_ROLE_LABEL = "scale.spectrum.ibm.com/daemon-selector=";
 export const WORKER_NODE_ROLE_LABEL = "node-role.kubernetes.io/worker=";
 export const MASTER_NODE_ROLE_LABEL = "node-role.kubernetes.io/master=";
 export const CPLANE_NODE_ROLE_LABEL = "node-role.kubernetes.io/control-plane=";

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,12 +10,7 @@ GIT_VERSION=$(git describe --always --tags || true)
 VERSION=${CI_UPSTREAM_VERSION:-${GIT_VERSION}}
 GIT_COMMIT=$(git rev-list -1 HEAD || true)
 COMMIT=${CI_UPSTREAM_COMMIT:-${GIT_COMMIT}}
-if date --utc -Iseconds >/dev/null 2>&1; then
-    BUILD_DATE=$(date --utc -Iseconds)
-else
-    # macOS fallback: emulate --utc -Iseconds
-    BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-fi
+BUILD_DATE=$(date --utc -Iseconds)
 
 LDFLAGS="-s -w "
 REPO="github.com/openshift-storage-scale/openshift-fusion-access-operator"

--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -138,16 +138,10 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 		ibmImageHash = ibmImageHash[:maxHashLength]
 	}
 
-	ibmImageHashLabel := getIBMCoreImageHashForLabel(ibmScaleImage)
-	if ibmImageHashLabel != "" {
-		selector = map[string]string{
-			"kubernetes.io/arch":                  "amd64",
-			"scale.spectrum.ibm.com/image-digest": ibmImageHashLabel,
-		}
-	} else {
-		selector = map[string]string{
-			"kubernetes.io/arch": "amd64",
-		}
+	// TODO: Fetch the selector from the cluster CR
+	selector = map[string]string{
+		"kubernetes.io/arch":                     "amd64",
+		"scale.spectrum.ibm.com/daemon-selector": "",
 	}
 
 	// See https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/specialized_hardware_and_driver_enablement/

--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -54,6 +54,10 @@ const (
 	KMMImageConfigKeyTLSSkipVerify      = "kmm_tls_skip_verify"
 	KMMImageConfigKeyRegistrySecretName = "kmm_image_registry_secret_name" //nolint:gosec
 	KMMRegistryPushPullSecretName       = "kmm-registry-push-pull-secret"  //nolint:gosec
+
+	// These has to match the values we use in the plugin code to label the selected nodes (STORAGE_ROLE_LABEL)
+	KMMNodeSelectorKey   = "scale.spectrum.ibm.com/daemon-selector"
+	KMMNodeSelectorValue = ""
 )
 
 // CreateOrUpdateKMMResources creates or updates the resources needed for the kernel module builds
@@ -138,10 +142,9 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 		ibmImageHash = ibmImageHash[:maxHashLength]
 	}
 
-	// TODO: Fetch the selector from the cluster CR
 	selector = map[string]string{
-		"kubernetes.io/arch":                     "amd64",
-		"scale.spectrum.ibm.com/daemon-selector": "",
+		"kubernetes.io/arch": "amd64",
+		KMMNodeSelectorKey:   KMMNodeSelectorValue,
 	}
 
 	// See https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/specialized_hardware_and_driver_enablement/

--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -33,7 +33,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -96,47 +95,12 @@ func CreateOrUpdateKMMResources(ctx context.Context, cl client.Client) error {
 	}
 	signModules := doSigningSecretsExist(ctx, cl, ns)
 
-	spectrumCluster, err := getCluster(ctx, cl)
-	if err != nil {
-		return fmt.Errorf("failed to get spectrumCluster in CreateOrUpdateKMMResources: %w", err)
-	}
-
-	labelSelector := getLabelSelector(spectrumCluster)
-
-	kernelModule := NewKMMModule(ns, ibmScaleImage, signModules, &KMMImageConfig, labelSelector)
+	kernelModule := NewKMMModule(ns, ibmScaleImage, signModules, &KMMImageConfig)
 	if err := kubeutils.CreateOrUpdateResource(ctx, cl, kernelModule, mutateKMMModule); err != nil {
 		return fmt.Errorf("failed to update kernelModule in CreateOrUpdateKMMResources: %w", err)
 	}
 
 	return nil
-}
-
-func getCluster(ctx context.Context, cl client.Client) (*unstructured.Unstructured, error) {
-	spectrumCluster := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "scale.spectrum.ibm.com/v1beta1",
-			"kind":       "Cluster",
-			"metadata": map[string]any{
-				"name":      "ibm-spectrum-scale",
-				"namespace": "ibm-spectrum-scale",
-			},
-		},
-	}
-
-	if err := cl.Get(ctx, types.NamespacedName{Namespace: "ibm-spectrum-scale", Name: "ibm-spectrum-scale"}, spectrumCluster); err != nil {
-		return nil, fmt.Errorf("failed to get spectrumCluster, please make sure your storage cluster has been created: %w", err)
-	}
-
-	return spectrumCluster, nil
-}
-
-func getLabelSelector(spectrumCluster *unstructured.Unstructured) map[string]string {
-	nodeSelectorRaw := spectrumCluster.Object["spec"].(map[string]any)["daemon"].(map[string]any)["nodeSelector"].(map[string]any)
-	labelSelector := make(map[string]string)
-	for k, v := range nodeSelectorRaw {
-		labelSelector[k] = v.(string)
-	}
-	return labelSelector
 }
 
 func doSigningSecretsExist(ctx context.Context, cl client.Client, namespace string) bool {
@@ -162,8 +126,9 @@ func mutateKMMModule(existing, desired *kmmv1beta1.Module) error {
 	return nil
 }
 
-func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KMMImageConfig, labelSelector map[string]string) *kmmv1beta1.Module {
+func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KMMImageConfig) *kmmv1beta1.Module {
 	var signing *kmmv1beta1.Sign
+	var selector map[string]string
 
 	ibmImageHash := getIBMCoreImageHash(ibmScaleImage)
 
@@ -171,6 +136,18 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 	const maxHashLength = 32
 	if len(ibmImageHash) > maxHashLength {
 		ibmImageHash = ibmImageHash[:maxHashLength]
+	}
+
+	ibmImageHashLabel := getIBMCoreImageHashForLabel(ibmScaleImage)
+	if ibmImageHashLabel != "" {
+		selector = map[string]string{
+			"kubernetes.io/arch":                  "amd64",
+			"scale.spectrum.ibm.com/image-digest": ibmImageHashLabel,
+		}
+	} else {
+		selector = map[string]string{
+			"kubernetes.io/arch": "amd64",
+		}
 	}
 
 	// See https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/specialized_hardware_and_driver_enablement/
@@ -240,7 +217,7 @@ func NewKMMModule(namespace, ibmScaleImage string, sign bool, kmmImageConfig *KM
 			ImageRepoSecret: func() *corev1.LocalObjectReference {
 				return &corev1.LocalObjectReference{Name: KMMRegistryPushPullSecretName}
 			}(),
-			Selector: labelSelector,
+			Selector: selector,
 		},
 	}
 }

--- a/internal/controller/kernelmodule/kernelmodule_test.go
+++ b/internal/controller/kernelmodule/kernelmodule_test.go
@@ -9,7 +9,6 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var _ = Describe("ExtractImageVersion", func() {
@@ -317,46 +316,6 @@ var _ = Describe("mutateKMMModule", func() {
 			Expect(existing.Spec.ModuleLoader.ServiceAccountName).To(Equal("new-service-account"))
 			Expect(existing.Spec.Selector).To(HaveKeyWithValue("env", "test"))
 			Expect(existing.Spec.ImageRepoSecret.Name).To(Equal("new-secret"))
-		})
-	})
-})
-
-var _ = Describe("getLabelSelector", func() {
-	var spectrumCluster *unstructured.Unstructured
-
-	Context("when spectrum cluster has valid nodeSelector", func() {
-		BeforeEach(func() {
-			spectrumCluster = &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "scale.spectrum.ibm.com/v1beta1",
-					"kind":       "Cluster",
-					"spec": map[string]any{
-						"daemon": map[string]any{
-							"nodeSelector": map[string]any{
-								"scale.spectrum.ibm.com/daemon-selector": "",
-								"kubernetes.io/arch":                     "amd64",
-							},
-						},
-					},
-				},
-			}
-		})
-
-		It("should return the correct label selector", func() {
-			result := getLabelSelector(spectrumCluster)
-
-			Expect(result).To(HaveLen(2))
-			Expect(result).To(HaveKeyWithValue("scale.spectrum.ibm.com/daemon-selector", ""))
-			Expect(result).To(HaveKeyWithValue("kubernetes.io/arch", "amd64"))
-		})
-
-		It("should return a map of string to string", func() {
-			result := getLabelSelector(spectrumCluster)
-
-			for k, v := range result {
-				Expect(k).To(BeAssignableToTypeOf(""))
-				Expect(v).To(BeAssignableToTypeOf(""))
-			}
 		})
 	})
 })


### PR DESCRIPTION
- **Revert "OCPNAS-214 | fix: Change label used to reconcile KMM Module to remove race condition on pod restart"**
- **Stop using the imagehash as selector for the kmm module**
- **fix: Add notes that nodeselector should be same as UI label**
