### PR TITLE
v1.0.0-rc.2

### DIFF
--- a/console/src/constants.ts
+++ b/console/src/constants.ts
@@ -10,7 +10,8 @@ export const MINIMUM_AMOUNT_OF_SHARED_DISKS_LITERAL = t("one");
 export const MINIMUM_AMOUNT_OF_MEMORY_GIB = 20;
 export const MINIMUM_AMOUNT_OF_MEMORY_GIB_LITERAL = "20 GiB";
 export const VALUE_NOT_AVAILABLE = "--";
-export const STORAGE_ROLE_LABEL = "scale.spectrum.ibm.com/role=storage";
+// This has to match the values we use in operator code (KMMNodeSelectorKey, KMMNodeSelectorValue)
+export const STORAGE_ROLE_LABEL = "scale.spectrum.ibm.com/daemon-selector=";
 export const WORKER_NODE_ROLE_LABEL = "node-role.kubernetes.io/worker=";
 export const MASTER_NODE_ROLE_LABEL = "node-role.kubernetes.io/master=";
 export const CPLANE_NODE_ROLE_LABEL = "node-role.kubernetes.io/control-plane=";

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,12 +10,7 @@ GIT_VERSION=$(git describe --always --tags || true)
 VERSION=${CI_UPSTREAM_VERSION:-${GIT_VERSION}}
 GIT_COMMIT=$(git rev-list -1 HEAD || true)
 COMMIT=${CI_UPSTREAM_COMMIT:-${GIT_COMMIT}}
-if date --utc -Iseconds >/dev/null 2>&1; then
-    BUILD_DATE=$(date --utc -Iseconds)
-else
-    # macOS fallback: emulate --utc -Iseconds
-    BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-fi
+BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S:%z")
 
 LDFLAGS="-s -w "
 REPO="github.com/openshift-storage-scale/openshift-fusion-access-operator"

--- a/internal/controller/kernelmodule/kernelmodule_test.go
+++ b/internal/controller/kernelmodule/kernelmodule_test.go
@@ -9,7 +9,6 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var _ = Describe("ExtractImageVersion", func() {
@@ -317,46 +316,6 @@ var _ = Describe("mutateKMMModule", func() {
 			Expect(existing.Spec.ModuleLoader.ServiceAccountName).To(Equal("new-service-account"))
 			Expect(existing.Spec.Selector).To(HaveKeyWithValue("env", "test"))
 			Expect(existing.Spec.ImageRepoSecret.Name).To(Equal("new-secret"))
-		})
-	})
-})
-
-var _ = Describe("getLabelSelector", func() {
-	var spectrumCluster *unstructured.Unstructured
-
-	Context("when spectrum cluster has valid nodeSelector", func() {
-		BeforeEach(func() {
-			spectrumCluster = &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "scale.spectrum.ibm.com/v1beta1",
-					"kind":       "Cluster",
-					"spec": map[string]any{
-						"daemon": map[string]any{
-							"nodeSelector": map[string]any{
-								"scale.spectrum.ibm.com/daemon-selector": "",
-								"kubernetes.io/arch":                     "amd64",
-							},
-						},
-					},
-				},
-			}
-		})
-
-		It("should return the correct label selector", func() {
-			result := getLabelSelector(spectrumCluster)
-
-			Expect(result).To(HaveLen(2))
-			Expect(result).To(HaveKeyWithValue("scale.spectrum.ibm.com/daemon-selector", ""))
-			Expect(result).To(HaveKeyWithValue("kubernetes.io/arch", "amd64"))
-		})
-
-		It("should return a map of string to string", func() {
-			result := getLabelSelector(spectrumCluster)
-
-			for k, v := range result {
-				Expect(k).To(BeAssignableToTypeOf(""))
-				Expect(v).To(BeAssignableToTypeOf(""))
-			}
 		})
 	})
 })

--- a/nudges/consolePlugin.env
+++ b/nudges/consolePlugin.env
@@ -1,1 +1,1 @@
-CONSOLE_PLUGIN_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-console-plugin-rhel9@sha256:a4dfac48b6033256fd9b7d1e5d59bbecdadda0c816b967606f8f9a703e4d4da4"
+CONSOLE_PLUGIN_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-console-plugin-rhel9@sha256:f25c4ed1541b5c8fd205b05380cc823f7471557d681bbfd2db8b98235f6d65e6"

--- a/nudges/deviceFinder.env
+++ b/nudges/deviceFinder.env
@@ -1,1 +1,1 @@
-DEVICEFINDER_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-devicefinder-rhel9@sha256:af23d5cfa508c6a5c6b7ae8ca52708b125f63ce29e33a9f8d13c12538d62ce37"
+DEVICEFINDER_IMAGE="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-devicefinder-rhel9@sha256:edab0e00cbe8d14e082a983dabc81a7f458b26f9b7cc5fc79806ea1417d9e750"

--- a/nudges/operator.env
+++ b/nudges/operator.env
@@ -1,1 +1,1 @@
-OPERATOR_IMG="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-rhel9-operator@sha256:a519f691f00dcab14d082da59fe7785a9fa32483712e77f081fabb8ff1558a7a"
+OPERATOR_IMG="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/openshift-fusion-access-rhel9-operator@sha256:f13c39abe11bfc320e0ded0bf962ad81381f740938f7392e63e006b2a8724262"


### PR DESCRIPTION
## Summary by Sourcery

Use a static node selector for kernel module management, removing dynamic label selection from the Spectrum cluster, and align console and build scripts with the new selector scheme.

Enhancements:
- Introduce KMMNodeSelectorKey and KMMNodeSelectorValue constants and apply a fixed selector in NewKMMModule
- Remove getCluster and getLabelSelector helpers along with dynamic label selector logic
- Update console plugin STORAGE_ROLE_LABEL to match the operator's node selector key/value

Build:
- Unify BUILD_DATE formatting in hack/build.sh to a single UTC timestamp format

Tests:
- Remove tests for getLabelSelector that are no longer applicable