### PR TITLE
fix: add cursor to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ go.work
 # editor and IDE paraphernalia
 .idea
 .vscode
+.cursor/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
quick change to allow people to have different cursor rules for the repo

## Summary by Sourcery

Bug Fixes:
- Add cursor-related entries to .gitignore to ignore personal cursor settings