### PR TITLE
fix: revert node label change because it broke upgrade of existing clusters

### DIFF
--- a/console/src/constants.ts
+++ b/console/src/constants.ts
@@ -11,7 +11,7 @@ export const MINIMUM_AMOUNT_OF_MEMORY_GIB = 20;
 export const MINIMUM_AMOUNT_OF_MEMORY_GIB_LITERAL = "20 GiB";
 export const VALUE_NOT_AVAILABLE = "--";
 // This has to match the values we use in operator code (KMMNodeSelectorKey, KMMNodeSelectorValue)
-export const STORAGE_ROLE_LABEL = "scale.spectrum.ibm.com/daemon-selector=";
+export const STORAGE_ROLE_LABEL = "scale.spectrum.ibm.com/role=storage";
 export const WORKER_NODE_ROLE_LABEL = "node-role.kubernetes.io/worker=";
 export const MASTER_NODE_ROLE_LABEL = "node-role.kubernetes.io/master=";
 export const CPLANE_NODE_ROLE_LABEL = "node-role.kubernetes.io/control-plane=";

--- a/internal/controller/kernelmodule/kernelmodule.go
+++ b/internal/controller/kernelmodule/kernelmodule.go
@@ -56,8 +56,9 @@ const (
 	KMMRegistryPushPullSecretName       = "kmm-registry-push-pull-secret"  //nolint:gosec
 
 	// These has to match the values we use in the plugin code to label the selected nodes (STORAGE_ROLE_LABEL)
-	KMMNodeSelectorKey   = "scale.spectrum.ibm.com/daemon-selector"
-	KMMNodeSelectorValue = ""
+	// Do not change this without also implementing a solution for upgrade of existing clusters using the current value.
+	KMMNodeSelectorKey   = "scale.spectrum.ibm.com/role"
+	KMMNodeSelectorValue = "storage"
 )
 
 // CreateOrUpdateKMMResources creates or updates the resources needed for the kernel module builds


### PR DESCRIPTION
Moving back to use the selector for cluster nodes used in 0.9.3. The selector can't be changed without also making changes to also recognize the old selector in order to handle upgrade of existing clusters.

Fixes: OCPNAS-245