### PR TITLE
refactor: Validates file system name length on creation

### DIFF
--- a/console/fusion-access.code-workspace
+++ b/console/fusion-access.code-workspace
@@ -28,11 +28,11 @@
       {
         "type": "chrome",
         "request": "launch",
-        "name": "with Google Chrome",
+        "name": "Google Chrome",
         "url": "http://localhost:9000/fusion-access",
         "webRoot": "${workspaceFolder}/src",
-      }
+      },
     ],
-    "compounds": []
-  }
+    "compounds": [],
+  },
 }

--- a/console/src/features/file-systems/components/FileSystemCreateForm.tsx
+++ b/console/src/features/file-systems/components/FileSystemCreateForm.tsx
@@ -35,7 +35,7 @@ export const FileSystemCreateForm: React.FC = () => {
               id="name"
               name="name"
               isRequired
-              minLength={1}
+              maxLength={vm.fileSystemNameMaxLength}
               value={vm.fileSystemName}
               placeholder="file-system-1"
               validated={vm.fileSystemNameErrorMessage ? "error" : "default"}

--- a/console/src/features/file-systems/hooks/useFileSystemCreateFormViewModel.ts
+++ b/console/src/features/file-systems/hooks/useFileSystemCreateFormViewModel.ts
@@ -9,6 +9,7 @@ import { useLunsViewModel, type Lun } from "./useLunsViewModel";
 
 type OnSelect = NonNullable<NonNullable<ThProps["select"]>["onSelect"]>;
 
+const NAME_FIELD_MAX_LENGTH = 128;
 const NAME_FIELD_VALIDATION_REGEX =
   /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 
@@ -75,15 +76,25 @@ export const useFileSystemCreateFormViewModel = () => {
       return;
     }
 
-    if (NAME_FIELD_VALIDATION_REGEX.test(fileSystemName)) {
-      form.setError("name", undefined);
-    } else {
-      form.setError(
-        "name",
-        t("Must match the expression: {{NAME_FIELD_VALIDATION_REGEX}}", {
-          NAME_FIELD_VALIDATION_REGEX,
-        })
-      );
+    switch (true) {
+      case fileSystemName.length > NAME_FIELD_MAX_LENGTH:
+        form.setError(
+          "name",
+          t("Must contain at most {{NAME_FIELD_MAX_LENGTH}} characters", {
+            NAME_FIELD_MAX_LENGTH,
+          })
+        );   
+        break;
+      case !NAME_FIELD_VALIDATION_REGEX.test(fileSystemName):
+        form.setError(
+          "name",
+          t("Must match the expression: {{NAME_FIELD_VALIDATION_REGEX}}", {
+            NAME_FIELD_VALIDATION_REGEX,
+          })
+        );
+        break;      
+      default:
+        form.setError("name", undefined);
     }
   }, [fileSystemName, form, t]);
 
@@ -104,6 +115,7 @@ export const useFileSystemCreateFormViewModel = () => {
       ({
         columns,
         fileSystemName,
+        fileSystemNameMaxLength: NAME_FIELD_MAX_LENGTH,
         fileSystemNameErrorMessage,
         luns,
         handleSelectLun,


### PR DESCRIPTION
Addresses:
- OCPNAS-186

Adds validation to the file system name input field during creation.

It now enforces a minimum and maximum length for the file system name, preventing users from entering names that are too short or too long.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>

## Summary by Sourcery

Add maximum length validation for file system names and update the form input to enforce it

New Features:
- Enforce a 128-character maximum on file system name during creation
- Pass the max length constant to the form view model and bind it to the input's maxLength attribute
- Refactor name validation logic to produce distinct errors for length and pattern violations