### PR TITLE
ocpnas-255 | fix: Update README to accurately describe supported versions of OCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The operator continuously monitors the system status and reports:
 
 ## Prerequisites
 
-- OpenShift 4.19 or higher
+- OpenShift 4.19 (Exclusively)
 - IBM Fusion Access entitlement (see https://access.ibmfusion.eu/)
 - Cluster administrator privileges
 - Supported storage hardware
@@ -109,7 +109,7 @@ The operator is distributed through the OpenShift OperatorHub:
 
 The operator currently supports:
 - IBM Storage Scale v5.2.3.1
-- OpenShift 4.12+
+- OpenShift 4.19 (Exclusively)
 - Architecture: x86_64, ppc64le, s390x
 
 ## Security Considerations


### PR DESCRIPTION
The readme currently suggests our operator supports versions other than 4.19. This is not the case at the moment and so should be updated.

## Summary by Sourcery

Documentation:
- Clarify that OpenShift 4.19 is exclusively supported in the prerequisites and supported versions sections of the README