### PR TITLE
fix: FS creation page shows LUNs that are not shared by all storage nodes

### DIFF
--- a/console/scripts/start-console.sh
+++ b/console/scripts/start-console.sh
@@ -62,6 +62,7 @@ pocker_args=(
     --pull=always
     --platform="$CONSOLE_IMAGE_PLATFORM"
     --name="openshift-console-${CONSOLE_VERSION%.*}"
+    -v="console-public-dir:/opt/bridge/static"
 )
 
 echo "Checking if the volume containing the console-app is already available..."
@@ -75,8 +76,6 @@ if ! pocker volume inspect console-public-dir; then
     pocker cp "${OPENSHIFT_CONSOLE_TMP}/frontend/public/dist/." tmp:/data/
     pocker stop tmp >/dev/null
     rm -rf "$OPENSHIFT_CONSOLE_TMP"
-
-    pocker_args+=(-v="console-public-dir:/opt/bridge/static")    
 fi
 
 if [ -x "$(command -v podman)" ]; then

--- a/console/src/features/file-systems/hooks/useCreateFileSystemHandler.ts
+++ b/console/src/features/file-systems/hooks/useCreateFileSystemHandler.ts
@@ -48,18 +48,6 @@ export const useCreateFileSystemHandler = (
   });
 
   return useCallback(async () => {
-    if (!luns.nodeName) {
-      dispatch({
-        type: "global/addAlert",
-        payload: {
-          title: "Node name is required to create a file system.",
-          variant: "warning",
-          dismiss: () => dispatch({ type: "global/dismissAlert" }),
-        },
-      });
-      return;
-    }
-
     try {
       dispatch({
         type: "global/updateCta",
@@ -147,18 +135,17 @@ function createLocalDisks(
   namespace: string
 ) {
   const promises: Promise<LocalDisk>[] = [];
-  for (const lun of luns.data.filter(l => l.isSelected)) {
-    const localDiskName =
-      `${lun.path.slice("/dev/".length)}-${lun.wwn}`.replaceAll(".", "-");
+  const selectedLuns = luns.data.filter((l) => l.isSelected);
+  for (const selectedLun of selectedLuns) {
     const promise = k8sCreate<LocalDisk>({
       model: localDiskModel,
       data: {
         apiVersion: "scale.spectrum.ibm.com/v1beta1",
         kind: "LocalDisk",
-        metadata: { name: localDiskName, namespace },
+        metadata: { name: selectedLun.wwn, namespace },
         spec: {
-          device: lun.path,
-          node: luns.nodeName!,
+          device: selectedLun.path,
+          node: selectedLun.nodeName,
         },
       },
     });

--- a/console/src/features/file-systems/hooks/useLunsViewModel.ts
+++ b/console/src/features/file-systems/hooks/useLunsViewModel.ts
@@ -25,7 +25,7 @@ export const useLunsViewModel = () => {
       dispatch({
         type: "global/addAlert",
         payload: {
-          title: t("Failed to load LocaDisks"),
+          title: t("Failed to load LocalDisks"),
           description: localDisks.error.message,
           variant: "danger",
           dismiss: () => dispatch({ type: "global/dismissAlert" }),

--- a/console/src/features/file-systems/hooks/useLunsViewModel.ts
+++ b/console/src/features/file-systems/hooks/useLunsViewModel.ts
@@ -123,7 +123,7 @@ const outDevicesUsedByLocalDisks =
     localDisks.length
       ? localDisks.find(
           (localDisk) =>
-            !localDisk.metadata?.name?.endsWith(disk.WWN.slice("uuid.".length))
+            !localDisk.metadata?.name?.endsWith(disk.WWN.slice(WWN_LENGTH * -1))
         )
       : true;
 
@@ -131,8 +131,9 @@ const toLun = (disk: DiscoveredDevice): Lun => {
   return {
     isSelected: false,
     path: disk.path,
-    wwn: disk.WWN.slice("uuid.".length),
-    // Note: Usage of 'GB' is intentional here
-    capacity: convert(disk.size, "B").to("GiB").toFixed(2) + " GB",
+    wwn: disk.WWN.slice(WWN_LENGTH * -1),
+    capacity: convert(disk.size, "B").to("GiB").toFixed(2) + " GiB",
   };
 };
+
+const WWN_LENGTH = 32;

--- a/console/src/features/file-systems/hooks/useLunsViewModel.ts
+++ b/console/src/features/file-systems/hooks/useLunsViewModel.ts
@@ -158,9 +158,7 @@ export interface Lun {
 const outDevicesUsedByLocalDisks =
   (localDisks: LocalDisk[]) =>
   (dd: WithNodeName<DiscoveredDevice>): boolean =>
-    localDisks.length
-      ? !localDisks.some((localDisk) => localDisk.metadata?.name === dd.WWN)
-      : true;
+    !localDisks.some((localDisk) => localDisk.metadata?.name === dd.WWN);
 
 /**
  * Transforms a discovered device entry (with nodeName) into a Lun object suitable to be displayed by the UI.
@@ -250,9 +248,5 @@ const getSharedDiscoveredDevicesRepresentatives = (
   ) as [string, WithNodeName<DiscoveredDevice>[]][];
 
   // Pick a representative discovered device from each group
-  const representativeDiscoveredDevices = onlySharedByAllStorageNodes.map(
-    ([_, dds]) => dds[0]
-  );
-
-  return representativeDiscoveredDevices;
+  return onlySharedByAllStorageNodes.map(([_, dds]) => dds[0]);
 };

--- a/console/src/features/file-systems/hooks/useStorageNodesLvdrs.ts
+++ b/console/src/features/file-systems/hooks/useStorageNodesLvdrs.ts
@@ -21,7 +21,7 @@ export const useStorageNodesLvdrs = (): NormalizedWatchK8sResult<
           (node) => node.metadata?.name === lvdr.spec.nodeName
         )
       ),
-    [lvdrs, storageNodes]
+    [lvdrs.data, storageNodes.data]
   );
 
   return useMemo(

--- a/console/src/features/storage-clusters/hooks/useNodesSelectionTableViewModel.ts
+++ b/console/src/features/storage-clusters/hooks/useNodesSelectionTableViewModel.ts
@@ -9,7 +9,7 @@ import type { TableColumn } from "@openshift-console/dynamic-plugin-sdk";
 import { useValidateMinimumRequirements } from "./useValidateMinimumRequirements";
 import type { NormalizedWatchK8sResult } from "@/shared/utils/console/UseK8sWatchResource";
 import { useStore } from "@/shared/store/provider";
-import type { State, Actions } from "@/shared/store/types";
+import type { Actions, State } from "@/shared/store/types";
 
 export interface NodesSelectionTableViewModel {
   columns: TableColumn<IoK8sApiCoreV1Node>[];
@@ -84,7 +84,7 @@ export const useNodesSelectionTableViewModel =
         ? wwnSetsList.reduce((previous, current) =>
             previous.intersection(current)
           ).size
-        : new Set<string>().size;
+        : 0;
     }, [lvdrs, selectedNodes]);
 
     const sharedDisksCountMessage = useMemo(() => {
@@ -96,10 +96,16 @@ export const useNodesSelectionTableViewModel =
         case n === 1:
           return t("{{n}} node selected", { n });
         case n >= 2 && s === 1:
-          return t("{{n}} nodes were selected, sharing {{s}} disk between them", { n, s });
+          return t(
+            "{{n}} nodes were selected, sharing {{s}} disk between them",
+            { n, s }
+          );
         default:
           // n >= 2 && s >= 2
-          return t("{{n}} nodes were selected, sharing {{s}} disks between them", { n, s });
+          return t(
+            "{{n}} nodes were selected, sharing {{s}} disks between them",
+            { n, s }
+          );
       }
     }, [selectedNodes.length, sharedDisksCount, t]);
 

--- a/console/src/shared/store/types.ts
+++ b/console/src/shared/store/types.ts
@@ -9,7 +9,7 @@ export type Actions =
 
 export interface State {
   docTitle: string;
-  alerts: Array<Alert>;
+  alerts: Alert[];
   cta: {
     isDisabled?: boolean;
     isLoading?: boolean;


### PR DESCRIPTION
Addresses:
-  OCPNAS-253

## Summary by Sourcery

Filter LUNs to include only devices shared by all storage nodes in the file system creation page, refactor the LUN view model for clearer device aggregation and selection, add error alerts for local disk and storage node discovery failures, update the create handler to use per-LUN node names, and apply minor script and type definition improvements.

Bug Fixes:
- Only display LUNs that are present on every storage node during file system creation
- Correct LocalDisk creation to use each LUN’s nodeName and WWN
- Ensure shared disks count falls back to zero when no storage nodes are selected

Enhancements:
- Refactor useLunsViewModel by extracting device grouping, filtering, and mapping into helper functions
- Include nodeName in the Lun type and view model to support per-node selection
- Add UI alerts for failures in local disk and storage node discovery
- Simplify the create file system handler by removing redundant nodeName validation
- Update useStorageNodesLvdrs to depend on data changes rather than entire objects

Build:
- Mount the console public directory volume in the start-console.sh script

Chores:
- Narrow the alerts array type in store definitions from Array<Alert> to Alert[]
- Adjust import ordering and formatting in various hooks