### PR TITLE
feat: add must-gather-image annotation to the CSV

### DIFF
--- a/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-fusion-access-operator.clusterserviceversion.yaml
@@ -29,6 +29,7 @@ metadata:
     operatorframework.io/initialization-resource: '{"apiVersion":"fusion.storage.openshift.io/v1alpha1","kind":"FusionAccess","metadata":{"name":"fusionaccess-object"},"spec":{"storageScaleVersion":"v5.2.3.1"}}'
     operatorframework.io/suggested-namespace: ibm-fusion-access
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/must-gather-image: icr.io/cpopen/ibm-spectrum-scale-must-gather:v5.2.3.1
     operators.openshift.io/valid-subscription: '["Openshift Container Platform","OpenShift
       Virtualization Engine"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.fusion.storage.openshift.io","localvolumediscoveries.fusion.storage.openshift.io"]'
@@ -64,9 +65,8 @@ spec:
     observability, platform-storage separation, and\ntrue storage abstraction, Fusion
     Access simplifies management and boosts\nefficiency.\n\n## Prerequisites and warnings\n\n-
     storage clusters require at least 3 available nodes\n- each available node must
-    have at least 20 GiB of RAM\n\nFor more information, see [Prerequisites and
-    configuration](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/virtualization-with-ibm-fusion-access-for-san#prerequisites).\n\nThis
-    operator will need an IBM Fusion Entitlement. See [https://access.ibmfusion.eu/](https://access.ibmfusion.eu/)\nfor
+    have at least 20 GiB of RAM\n\nFor more information, see [Prerequisites and configuration](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/virtualization-with-ibm-fusion-access-for-san#prerequisites).\n\n
+    This operator will need an IBM Fusion Entitlement. See [https://access.ibmfusion.eu/](https://access.ibmfusion.eu/)\nfor
     additional information.\n"
   displayName: Fusion Access for SAN
   icon:


### PR DESCRIPTION
Adds an annotation to the operator CSV so that the CNSA must-gather will be run when the --all-images option is given to 'oc adm must-gather'.

See the comments in https://issues.redhat.com/browse/OCPNAS-198 for more background.