### PR TITLE
Ocpnas 271 - Remove usage of "latest" base images for explicit ones

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,7 +1,7 @@
 RPM lockfile generation:
 
 ```
-BASE_IMAGE=registry.redhat.io/ubi10/ubi:latest
+BASE_IMAGE=registry.redhat.io/ubi10/ubi:10.0
 podman run -it $BASE_IMAGE cat /etc/yum.repos.d/ubi.repo > ubi.repo
 sed -i 's/\[ubi-10/[ubi-10-for-$basearch/' ubi.repo
 rpm-lockfile-prototype --image $BASE_IMAGE rpms.in.yaml

--- a/templates/console-plugin.Dockerfile.template
+++ b/templates/console-plugin.Dockerfile.template
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-22:latest AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-22:9.6 AS builder
 
 USER root
 
@@ -10,7 +10,7 @@ RUN npm ci --ignore-scripts && npm run build
 RUN mkdir licenses
 COPY LICENSE licenses/
 
-FROM registry.access.redhat.com/ubi9/nginx-120:latest
+FROM registry.access.redhat.com/ubi9/nginx-120:9.6
 LABEL \
     com.redhat.openshift.versions="${SUPPORTED_OCP_VERSIONS}" \
     com.redhat.component="Console plugin image for OpenShift Fusion Access Operator" \

--- a/templates/devicefinder.Dockerfile.template
+++ b/templates/devicefinder.Dockerfile.template
@@ -9,7 +9,7 @@ RUN make build-devicefinder
 RUN mkdir licenses
 COPY LICENSE licenses/
 
-FROM registry.redhat.io/ubi10/ubi:latest
+FROM registry.redhat.io/ubi10/ubi:10.0
 
 COPY --from=builder /workspace/_output/bin/devicefinder /usr/bin/
 RUN dnf install -y udev && dnf clean all

--- a/templates/operator.Dockerfile.template
+++ b/templates/operator.Dockerfile.template
@@ -30,7 +30,7 @@ COPY LICENSE licenses/
 RUN hack/build.sh
 
 # UBI is larger (158Mb vs. 56Mb) but approved by RH
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 WORKDIR /
 COPY --from=builder /workspace/files/ /files/
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Using latest base images can be dangerous for creating stable applications and increase the chances of introducing unexpected bugs as well as security vulnerabilities. I've changed the instances I found to the currently "latest" versions of ubi 9 and ubi 10

## Summary by Sourcery

Pin base images in Dockerfiles and build instructions to explicit UBI versions instead of using the 'latest' tag

Enhancements:
- Replace 'latest' tag with UBI 10.0 in hack/README.md
- Update console-plugin, devicefinder, and operator Dockerfile templates to use explicit UBI base images