### PR TITLE
build: fix docker file template

### DIFF
--- a/templates/bundle.Dockerfile.template
+++ b/templates/bundle.Dockerfile.template
@@ -43,8 +43,6 @@ LABEL operators.operatorframework.io.metrics.project_layout=ansible.sdk.operator
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 
-
-
 LABEL \
     com.redhat.component="OpenShift Fusion Access Operator" \
     distribution-scope="public" \
@@ -59,4 +57,4 @@ LABEL \
     summary="" \
     io.k8s.display-name="OpenShift Fusion Access Operator" \
     io.openshift.tags="openshift,fusion,access,san" \
-    License="Apache License 2.0" \
+    License="Apache License 2.0"


### PR DESCRIPTION
The bundle docker file template has a spurious \ at the end of the labels which causes buildah to choke when parsing the generated docker file with error 'Syntax error - can't find = in "COPY". Must be of the form: name=value'